### PR TITLE
Fix false conflict when user resubmits their own username or email on profile update and created a unit test project

### DIFF
--- a/src/AreWeDoomd.Application/Common/Interfaces/IUserRepository.cs
+++ b/src/AreWeDoomd.Application/Common/Interfaces/IUserRepository.cs
@@ -8,8 +8,8 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
     Task<User?> GetByEmailAsync(string email, CancellationToken cancellationToken);
     Task<User?> GetByUsernameAsync(string username, CancellationToken cancellationToken);
-    Task<bool> IsUsernameTakenAsync(string username, CancellationToken cancellationToken);
-    Task<bool> IsEmailTakenAsync(string email, CancellationToken cancellationToken);
+    Task<bool> IsUsernameTakenAsync(string username, Guid? excludeUserId, CancellationToken cancellationToken);
+    Task<bool> IsEmailTakenAsync(string email, Guid? excludeUserId, CancellationToken cancellationToken);
     Task<IReadOnlyList<SearchUserResult>> SearchByQueryAsync(string query, CancellationToken cancellationToken);
     Task AddAsync(User user, CancellationToken cancellationToken);
     Task UpdateAsync(User user, CancellationToken cancellationToken);

--- a/src/AreWeDoomd.Application/Features/Authentication/Commands/RegisterUser/RegisterUserCommandHandler.cs
+++ b/src/AreWeDoomd.Application/Features/Authentication/Commands/RegisterUser/RegisterUserCommandHandler.cs
@@ -19,12 +19,12 @@ public sealed class RegisterUserCommandHandler(
         var normalizedUsername = request.Username.Trim();
         var normalizedEmail = request.Email.Trim().ToLowerInvariant();
 
-        if (await userRepository.IsUsernameTakenAsync(normalizedUsername, cancellationToken))
+        if (await userRepository.IsUsernameTakenAsync(normalizedUsername, null, cancellationToken))
         {
             return Result<AuthResult>.Conflict("auth.username_taken", "Username is already taken.");
         }
 
-        if (await userRepository.IsEmailTakenAsync(normalizedEmail, cancellationToken))
+        if (await userRepository.IsEmailTakenAsync(normalizedEmail, null, cancellationToken))
         {
             return Result<AuthResult>.Conflict("auth.email_taken", "Email is already registered.");
         }

--- a/src/AreWeDoomd.Application/Features/Users/Commands/UpdateUserProfile/UpdateUserProfileCommandHandler.cs
+++ b/src/AreWeDoomd.Application/Features/Users/Commands/UpdateUserProfile/UpdateUserProfileCommandHandler.cs
@@ -26,7 +26,7 @@ public sealed class UpdateUserProfileCommandHandler(
         {
             var normalizedUsername = request.Username.Trim();
 
-            if (await userRepository.IsUsernameTakenAsync(normalizedUsername, cancellationToken))
+            if (await userRepository.IsUsernameTakenAsync(normalizedUsername, request.UserId, cancellationToken))
             {
                 return Result<UserProfileResult>.Conflict("user.username_taken", "Username is already taken.");
             }
@@ -38,7 +38,7 @@ public sealed class UpdateUserProfileCommandHandler(
         {
             var normalizedEmail = request.Email.Trim().ToLowerInvariant();
 
-            if (await userRepository.IsEmailTakenAsync(normalizedEmail, cancellationToken))
+            if (await userRepository.IsEmailTakenAsync(normalizedEmail, request.UserId, cancellationToken))
             {
                 return Result<UserProfileResult>.Conflict("user.email_taken", "Email is already registered.");
             }

--- a/src/AreWeDoomd.Infrastructure/Common/Repositories/UserRepository.cs
+++ b/src/AreWeDoomd.Infrastructure/Common/Repositories/UserRepository.cs
@@ -29,11 +29,11 @@ public sealed class UserRepository(AreWeDoomdDbContext dbContext) : IUserReposit
             .FirstOrDefaultAsync(u => u.Username == username, cancellationToken);
     }
 
-    public Task<bool> IsUsernameTakenAsync(string username, CancellationToken cancellationToken)
-        => dbContext.Users.AnyAsync(u => u.Username == username, cancellationToken);
+    public Task<bool> IsUsernameTakenAsync(string username, Guid? excludeUserId, CancellationToken cancellationToken)
+        => dbContext.Users.AnyAsync(u => u.Username == username && u.Id != excludeUserId, cancellationToken);
 
-    public Task<bool> IsEmailTakenAsync(string email, CancellationToken cancellationToken)
-        => dbContext.Users.AnyAsync(u => u.Email == email, cancellationToken);
+    public Task<bool> IsEmailTakenAsync(string email, Guid? excludeUserId, CancellationToken cancellationToken)
+        => dbContext.Users.AnyAsync(u => u.Email == email && u.Id != excludeUserId, cancellationToken);
 
     public async Task<IReadOnlyList<SearchUserResult>> SearchByQueryAsync(
         string query,

--- a/tests/AreWeDoomd.UnitTests/AreWeDoomd.UnitTests.csproj
+++ b/tests/AreWeDoomd.UnitTests/AreWeDoomd.UnitTests.csproj
@@ -1,9 +1,26 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AreWeDoomd.Application\AreWeDoomd.Application.csproj" />
+    <ProjectReference Include="..\..\src\AreWeDoomd.Domain\AreWeDoomd.Domain.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/AreWeDoomd.UnitTests/Features/Authentication/Commands/RegisterUser/RegisterUserCommandHandlerTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Features/Authentication/Commands/RegisterUser/RegisterUserCommandHandlerTests.cs
@@ -1,0 +1,172 @@
+using AreWeDoomd.Application.Common.Interfaces;
+using AreWeDoomd.Application.Common.Results;
+using AreWeDoomd.Application.Features.Authentication.Commands.RegisterUser;
+using AreWeDoomd.Domain.Users;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Features.Authentication.Commands.RegisterUser;
+
+public sealed class RegisterUserCommandHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IPasswordHasher> _passwordHasherMock;
+    private readonly Mock<IAccessTokenGenerator> _accessTokenGeneratorMock;
+    private readonly Mock<IDateTimeProvider> _dateTimeProviderMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly RegisterUserCommandHandler _handler;
+
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public RegisterUserCommandHandlerTests()
+    {
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _passwordHasherMock = new Mock<IPasswordHasher>();
+        _accessTokenGeneratorMock = new Mock<IAccessTokenGenerator>();
+        _dateTimeProviderMock = new Mock<IDateTimeProvider>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+
+        _dateTimeProviderMock.Setup(d => d.UtcNow).Returns(Now);
+        _passwordHasherMock.Setup(p => p.Hash(It.IsAny<string>())).Returns("hashedpassword_at_least_20_chars");
+        _accessTokenGeneratorMock.Setup(a => a.Generate(It.IsAny<User>())).Returns("access-token");
+
+        _handler = new RegisterUserCommandHandler(
+            _userRepositoryMock.Object,
+            _passwordHasherMock.Object,
+            _accessTokenGeneratorMock.Object,
+            _dateTimeProviderMock.Object,
+            _unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameIsAlreadyTaken_ShouldReturnConflict()
+    {
+        var command = new RegisterUserCommand("takenuser", "new@example.com", "password123", UserType.Human);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("takenuser", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.ErrorType.ShouldBe(ErrorType.Conflict);
+        result.Error!.Code.ShouldBe("auth.username_taken");
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailIsAlreadyTaken_ShouldReturnConflict()
+    {
+        var command = new RegisterUserCommand("newuser", "taken@example.com", "password123", UserType.Human);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("newuser", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _userRepositoryMock
+            .Setup(r => r.IsEmailTakenAsync("taken@example.com", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.ErrorType.ShouldBe(ErrorType.Conflict);
+        result.Error!.Code.ShouldBe("auth.email_taken");
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameAndEmailAreAvailable_ShouldReturnSuccess()
+    {
+        var command = new RegisterUserCommand("newuser", "new@example.com", "password123", UserType.Human);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("newuser", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _userRepositoryMock
+            .Setup(r => r.IsEmailTakenAsync("new@example.com", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Username.ShouldBe("newuser");
+        result.Value.Email.ShouldBe("new@example.com");
+        result.Value.AccessToken.ShouldBe("access-token");
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameAndEmailAreAvailable_ShouldPersistUser()
+    {
+        var command = new RegisterUserCommand("newuser", "new@example.com", "password123", UserType.Human);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("newuser", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _userRepositoryMock
+            .Setup(r => r.IsEmailTakenAsync("new@example.com", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _userRepositoryMock.Verify(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameIsTaken_ShouldNotCheckEmail()
+    {
+        var command = new RegisterUserCommand("takenuser", "new@example.com", "password123", UserType.Human);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("takenuser", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _userRepositoryMock.Verify(
+            r => r.IsEmailTakenAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameIsTaken_ShouldNotPersistUser()
+    {
+        var command = new RegisterUserCommand("takenuser", "new@example.com", "password123", UserType.Human);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("takenuser", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _userRepositoryMock.Verify(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRegistering_ShouldPassNullAsExcludeUserIdToUniquenessChecks()
+    {
+        var command = new RegisterUserCommand("newuser", "new@example.com", "password123", UserType.Human);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _userRepositoryMock
+            .Setup(r => r.IsEmailTakenAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _userRepositoryMock.Verify(
+            r => r.IsUsernameTakenAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _userRepositoryMock.Verify(
+            r => r.IsEmailTakenAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/tests/AreWeDoomd.UnitTests/Features/Users/Commands/UpdateUserProfile/UpdateUserProfileCommandHandlerTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Features/Users/Commands/UpdateUserProfile/UpdateUserProfileCommandHandlerTests.cs
@@ -1,0 +1,186 @@
+using AreWeDoomd.Application.Common.Interfaces;
+using AreWeDoomd.Application.Common.Results;
+using AreWeDoomd.Application.Features.Users.Commands.UpdateUserProfile;
+using AreWeDoomd.Domain.Users;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Features.Users.Commands.UpdateUserProfile;
+
+public sealed class UpdateUserProfileCommandHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IDateTimeProvider> _dateTimeProviderMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly UpdateUserProfileCommandHandler _handler;
+
+    private static readonly DateTimeOffset Now = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    public UpdateUserProfileCommandHandlerTests()
+    {
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _dateTimeProviderMock = new Mock<IDateTimeProvider>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+
+        _dateTimeProviderMock.Setup(d => d.UtcNow).Returns(Now);
+
+        _handler = new UpdateUserProfileCommandHandler(
+            _userRepositoryMock.Object,
+            _dateTimeProviderMock.Object,
+            _unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserNotFound_ShouldReturnNotFound()
+    {
+        var command = new UpdateUserProfileCommand(Guid.NewGuid(), "newname", null, null);
+
+        _userRepositoryMock
+            .Setup(r => r.GetByIdAsync(command.UserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.ErrorType.ShouldBe(ErrorType.NotFound);
+        result.Error!.Code.ShouldBe("user.not_found");
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameIsSameAsCurrentUser_ShouldReturnSuccess()
+    {
+        var user = CreateUser();
+        var command = new UpdateUserProfileCommand(user.Id, user.Username, null, null);
+
+        _userRepositoryMock
+            .Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync(user.Username, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameIsTakenByAnotherUser_ShouldReturnConflict()
+    {
+        var user = CreateUser();
+        var command = new UpdateUserProfileCommand(user.Id, "takenname", null, null);
+
+        _userRepositoryMock
+            .Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("takenname", user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.ErrorType.ShouldBe(ErrorType.Conflict);
+        result.Error!.Code.ShouldBe("user.username_taken");
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailIsSameAsCurrentUser_ShouldReturnSuccess()
+    {
+        var user = CreateUser();
+        var command = new UpdateUserProfileCommand(user.Id, null, user.Email, null);
+
+        _userRepositoryMock
+            .Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _userRepositoryMock
+            .Setup(r => r.IsEmailTakenAsync(user.Email, user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailIsTakenByAnotherUser_ShouldReturnConflict()
+    {
+        var user = CreateUser();
+        var command = new UpdateUserProfileCommand(user.Id, null, "taken@example.com", null);
+
+        _userRepositoryMock
+            .Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _userRepositoryMock
+            .Setup(r => r.IsEmailTakenAsync("taken@example.com", user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.ErrorType.ShouldBe(ErrorType.Conflict);
+        result.Error!.Code.ShouldBe("user.email_taken");
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameAndEmailAreAvailable_ShouldReturnSuccess()
+    {
+        var user = CreateUser();
+        var command = new UpdateUserProfileCommand(user.Id, "newname", "new@example.com", null);
+
+        _userRepositoryMock
+            .Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("newname", user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _userRepositoryMock
+            .Setup(r => r.IsEmailTakenAsync("new@example.com", user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.Username.ShouldBe("newname");
+        result.Value.Email.ShouldBe("new@example.com");
+    }
+
+    [Fact]
+    public async Task Handle_WhenUsernameIsTakenByAnotherUser_ShouldNotCallIsEmailTaken()
+    {
+        var user = CreateUser();
+        var command = new UpdateUserProfileCommand(user.Id, "takenname", "new@example.com", null);
+
+        _userRepositoryMock
+            .Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _userRepositoryMock
+            .Setup(r => r.IsUsernameTakenAsync("takenname", user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _userRepositoryMock.Verify(
+            r => r.IsEmailTakenAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private static User CreateUser()
+    {
+        return new User(
+            Guid.NewGuid(),
+            "testuser",
+            "test@example.com",
+            "hashedpassword_at_least_20_chars",
+            UserType.Human,
+            Now);
+    }
+}


### PR DESCRIPTION
## Summary
- `IsUsernameTakenAsync` and `IsEmailTakenAsync` on `IUserRepository` now accept a nullable `excludeUserId` parameter
- `UserRepository` applies `u.Id != excludeUserId` to the EF query so the check only fires when *another* user owns the value
- `UpdateUserProfileCommandHandler` passes `request.UserId` to exclude the current user's own row
- `RegisterUserCommandHandler` passes `null` — no exclusion needed during registration, behaviour unchanged
## What was the bug?
When a user submitted a profile update containing their current username or email (e.g. they only wanted to change their biography), the uniqueness check found their own row in the database and returned `409 Conflict`. The check asked "does this value exist?" instead of "does *another* user own this value?".
## What changed
| `IUserRepository` | Added `Guid? excludeUserId` to both uniqueness check signatures |
| `UserRepository` | Filters out `excludeUserId` from the EF `AnyAsync` query |
| `UpdateUserProfileCommandHandler` | Passes `request.UserId` as the excluded user |
| `RegisterUserCommandHandler` | Passes `null` — preserves original behaviour |
## Tests
Added unit test project (xUnit + Moq + Shouldly) with 14 tests across two handlers:
**UpdateUserProfileCommandHandler** — user not found, own username/email no longer conflicts, another user's username/email still conflicts, happy path, early return skips email check when username already conflicts.
**RegisterUserCommandHandler** — taken username/email conflict, happy path, persistence verified, early return skips email check, `null` explicitly verified as `excludeUserId` for both checks.
All 14 tests pass. Endpoints manually verified end-to-end against a live database.
## Reviewer notes
The only observable behaviour change is on `PATCH /api/users/me` — submitting your own current username or email now returns `200` instead of `409`. All other flows are unaffected.