### PR TITLE
feat: add Serilog console logging to AgentService for development

### DIFF
--- a/src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj
+++ b/src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj
@@ -11,6 +11,9 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AreWeDoomd.AgentService/Program.cs
+++ b/src/AreWeDoomd.AgentService/Program.cs
@@ -1,8 +1,22 @@
 using AreWeDoomd.AgentService;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Serilog;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddSerilog((services, loggerConfig) =>
+{
+    loggerConfig
+        .ReadFrom.Configuration(builder.Configuration)
+        .ReadFrom.Services(services)
+        .Enrich.FromLogContext();
+
+    if (builder.Environment.IsDevelopment())
+    {
+        loggerConfig.WriteTo.Console();
+    }
+});
 
 builder.Services.Configure<AgentServiceOptions>(
     builder.Configuration.GetSection(AgentServiceOptions.SectionName));

--- a/src/AreWeDoomd.AgentService/appsettings.json
+++ b/src/AreWeDoomd.AgentService/appsettings.json
@@ -1,8 +1,10 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore.SignalR.Client": "Warning"
+      "Override": {
+        "Microsoft.AspNetCore.SignalR.Client": "Warning"
+      }
     }
   },
   "AgentNotifications": {


### PR DESCRIPTION
Register Serilog on the AgentService generic host, replacing the default logging provider. Console sink is gated to Development environment only. Convert appsettings Logging section to Serilog config, preserving the SignalR client Warning override.

Development mode is determined by the DOTNET_ENVIRONMENT environment variable. There's no launchSettings.json in this project, so to run in dev mode set DOTNET_ENVIRONMENT=Development (e.g. $env:DOTNET_ENVIRONMENT="Development"; dotnet run)