### PR TITLE
Containerize local dev environment (Api, AgentService, Redis via docker compose)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Build artifacts
+**/bin/
+**/obj/
+
+# VCS / tooling / docs — not needed in the image
+.git/
+.github/
+.claude/
+.vs/
+docs/
+postman/
+tests/
+
+# Root-level docs only (AgentService Prompts/*.md must stay included)
+*.md
+*.png
+
+# Local secrets and compose files (config comes via environment variables)
+.env
+docker-compose.yml

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Copy this file to .env and fill in real values. .env is git-ignored.
+
+# Connection string to the existing SQL Server (NOT containerized).
+# This project currently uses an Azure SQL database; any SQL-auth connection
+# string works. For a SQL Server on your host machine, use
+# "host.docker.internal" as the server name - and note that Windows/Trusted
+# auth does NOT work from Linux containers, only SQL authentication.
+AREWEDOOMD_SQL_CONNECTION=Server=tcp:<server>,1433;Initial Catalog=<database>;User ID=<user>;Password=<password>;Encrypt=True;
+
+# JWT signing key (dev value; any sufficiently long string)
+JWT_KEY=dev-signing-key-change-this-before-production-12345
+
+# Shared secret between Api and AgentService (must match on both sides;
+# compose injects the same value into both containers)
+AGENT_SHARED_SECRET=dev-agent-shared-secret-change-me
+
+# Chat provider API keys (leave empty for providers you don't use)
+GEMINI_API_KEY=
+ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ JWT_KEY=dev-signing-key-change-this-before-production-12345
 # compose injects the same value into both containers)
 AGENT_SHARED_SECRET=dev-agent-shared-secret-change-me
 
-# Chat provider API keys (leave empty for providers you don't use)
+# Chat provider API keys (leave empty for providers you don't use).
+# GEMINI_API_KEY is read directly by the AgentService; ANTHROPIC_API_KEY is
+# injected by compose as ChatProviders__Anthropic__ApiKey.
 GEMINI_API_KEY=
 ANTHROPIC_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -795,3 +795,6 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/rider,visualstudio,visualstudiocode,csharp,aspnetcore
 /.claude
+
+# Local container environment values (secrets) — see .env.example
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# Local development environment.
+#   1. Copy .env.example to .env and fill in values.
+#   2. docker compose up --build
+# The IDE workflow (dotnet run) is unaffected by this file.
+services:
+  api:
+    build:
+      context: .
+      dockerfile: src/AreWeDoomd.Api/Dockerfile
+    ports:
+      - "5188:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__AreWeDoomdSql: ${AREWEDOOMD_SQL_CONNECTION}
+      Jwt__Key: ${JWT_KEY}
+      AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
+      # SMTP is optional for local dev; add Smtp__Host etc. here when needed.
+
+  agent-service:
+    build:
+      context: .
+      dockerfile: src/AreWeDoomd.AgentService/Dockerfile
+    depends_on:
+      - api
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      # Container-to-container traffic goes via the compose service name.
+      AgentNotifications__HubUrl: http://api:8080/hubs/agent-notifications
+      AgentNotifications__ApiBaseUrl: http://api:8080
+      AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      ChatProviders__Anthropic__ApiKey: ${ANTHROPIC_API_KEY:-}
+
+  redis:
+    # Provisioned ahead of use; no app config points at it yet.
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,23 @@ services:
       Jwt__Key: ${JWT_KEY}
       AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
       # SMTP is optional for local dev; add Smtp__Host etc. here when needed.
+    healthcheck:
+      # "Is the port accepting connections?" via bash's built-in /dev/tcp —
+      # the slim aspnet image ships no curl/wget. Lets agent-service wait for
+      # actual readiness instead of just container start.
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8080"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 5s
 
   agent-service:
     build:
       context: .
       dockerfile: src/AreWeDoomd.AgentService/Dockerfile
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     environment:
       DOTNET_ENVIRONMENT: Development
       # Container-to-container traffic goes via the compose service name.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       AgentNotifications__HubUrl: http://api:8080/hubs/agent-notifications
       AgentNotifications__ApiBaseUrl: http://api:8080
       AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
+      # Passed raw (not ChatProviders__Gemini__ApiKey): the AgentService's
+      # Program.cs maps GEMINI_API_KEY onto ChatProviders:Gemini:ApiKey itself.
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
       ChatProviders__Anthropic__ApiKey: ${ANTHROPIC_API_KEY:-}
 

--- a/docs/superpowers/plans/2026-06-11-containerization.md
+++ b/docs/superpowers/plans/2026-06-11-containerization.md
@@ -1,0 +1,362 @@
+# Containerization (Local Dev Compose) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One-command local dev environment (`docker compose up --build`) running AreWeDoomd.Api, AreWeDoomd.AgentService, and Redis in containers, against the existing external SQL Server.
+
+**Architecture:** Two multi-stage Dockerfiles (build context = repo root so project references resolve), one root `docker-compose.yml` with three services on the default network, config injected exclusively via environment variables sourced from a git-ignored `.env`. `appsettings*.json` and the IDE workflow stay untouched.
+
+**Tech Stack:** .NET 10 (`mcr.microsoft.com/dotnet/sdk:10.0`, `aspnet:10.0`, `runtime:10.0`), Docker Compose, `redis:7-alpine`.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-containerization-design.md`
+
+---
+
+## Facts the implementer needs (verified against the codebase)
+
+- Project reference graph:
+  - `AreWeDoomd.Api` → `Application`, `Infrastructure`, `ActivityNotifications.Contracts`; `Application` → `Domain`, `ActivityNotifications.Contracts`; `Infrastructure` → `Application`.
+  - `AreWeDoomd.AgentService` → `ActivityNotifications.Contracts` only.
+- The Api is a `WebApplication` (reads `ASPNETCORE_ENVIRONMENT`); .NET 8+ `aspnet` images listen on port **8080** by default. `UseHttpsRedirection()` no-ops with a warning when no HTTPS port is configured — acceptable for dev.
+- The Api throws at startup if `AgentNotifications:SharedSecret` is missing (`src/AreWeDoomd.Api/Program.cs:89`).
+- Scalar UI + OpenAPI are mapped only in `Development` (`Program.cs:95-102`) — used for verification.
+- The AgentService is a generic host (`Host.CreateApplicationBuilder`, reads `DOTNET_ENVIRONMENT`), assembly `AreWeDoomd.AgentService.dll`. It already maps a raw `GEMINI_API_KEY` env var onto `ChatProviders:Gemini:ApiKey` (`src/AreWeDoomd.AgentService/Program.cs:20-27`).
+- AgentService's `Prompts/**/*.md` are `Content` items with `CopyToOutputDirectory` — they flow into the publish output automatically.
+- SQL connection string key: `ConnectionStrings:AreWeDoomdSql` (`src/AreWeDoomd.Infrastructure/DependencyInjection.cs:51`). **Containers cannot use Windows/Trusted authentication** — the `.env` connection string must use SQL auth and reach the host DB via `host.docker.internal`.
+- Docker Desktop must be running on this Windows machine. Check with `docker version` before starting; if the daemon is down, ask the user to start Docker Desktop.
+
+## File Structure
+
+```
+.dockerignore                                 (create)
+.gitignore                                    (modify: ignore .env)
+src/AreWeDoomd.Api/Dockerfile                 (create)
+src/AreWeDoomd.AgentService/Dockerfile        (create)
+docker-compose.yml                            (create)
+.env.example                                  (create, committed)
+.env                                          (create locally, NOT committed)
+```
+
+---
+
+### Task 1: Build hygiene — `.dockerignore` and `.gitignore`
+
+**Files:**
+- Create: `.dockerignore`
+- Modify: `.gitignore` (append at end, after the `/.claude` line)
+
+- [ ] **Step 1: Create `.dockerignore`**
+
+Note: in dockerignore syntax, a bare `*.md` matches only root-level files — it must NOT be written as `**/*.md`, because the AgentService needs its `Prompts/**/*.md` files inside the build context.
+
+```
+# Build artifacts
+**/bin/
+**/obj/
+
+# VCS / tooling / docs — not needed in the image
+.git/
+.github/
+.claude/
+.vs/
+docs/
+postman/
+tests/
+
+# Root-level docs only (AgentService Prompts/*.md must stay included)
+*.md
+*.png
+
+# Local secrets and compose files (config comes via environment variables)
+.env
+docker-compose.yml
+```
+
+- [ ] **Step 2: Append `.env` to `.gitignore`**
+
+Append these lines to the end of `D:\AreWeDoomd.Api\.gitignore`:
+
+```
+# Local container environment values (secrets) — see .env.example
+.env
+```
+
+- [ ] **Step 3: Verify git ignores `.env`**
+
+Run:
+```powershell
+Set-Content -Path .env -Value "TEST=1" -Encoding utf8; git check-ignore .env; git status --short
+```
+Expected: `git check-ignore` prints `.env`; `git status` shows only `.gitignore` and `.dockerignore` as changes (no `.env`).
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add .gitignore .dockerignore; git commit -m "chore: add .dockerignore and git-ignore .env"
+```
+
+---
+
+### Task 2: Api Dockerfile
+
+**Files:**
+- Create: `src/AreWeDoomd.Api/Dockerfile`
+
+- [ ] **Step 1: Write the Dockerfile**
+
+```dockerfile
+# Build context must be the repository root:
+#   docker build -f src/AreWeDoomd.Api/Dockerfile .
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy project files first so 'dotnet restore' is layer-cached
+COPY src/AreWeDoomd.Api/AreWeDoomd.Api.csproj src/AreWeDoomd.Api/
+COPY src/AreWeDoomd.Application/AreWeDoomd.Application.csproj src/AreWeDoomd.Application/
+COPY src/AreWeDoomd.Domain/AreWeDoomd.Domain.csproj src/AreWeDoomd.Domain/
+COPY src/AreWeDoomd.Infrastructure/AreWeDoomd.Infrastructure.csproj src/AreWeDoomd.Infrastructure/
+COPY src/AreWeDoomd.ActivityNotifications.Contracts/AreWeDoomd.ActivityNotifications.Contracts.csproj src/AreWeDoomd.ActivityNotifications.Contracts/
+RUN dotnet restore src/AreWeDoomd.Api/AreWeDoomd.Api.csproj
+
+COPY src/ src/
+RUN dotnet publish src/AreWeDoomd.Api/AreWeDoomd.Api.csproj -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "AreWeDoomd.Api.dll"]
+```
+
+- [ ] **Step 2: Build the image (this is the test)**
+
+Run from the repo root:
+```powershell
+docker build -f src/AreWeDoomd.Api/Dockerfile -t arewedoomd-api:dev .
+```
+Expected: build succeeds, final line reports the image was tagged `arewedoomd-api:dev`. First run downloads base images (slow); that's normal.
+
+- [ ] **Step 3: Smoke-test the container fails fast for the RIGHT reason**
+
+The Api requires `AgentNotifications:SharedSecret`; without config it must exit with our known startup error (proves the entrypoint and publish output are correct):
+```powershell
+docker run --rm arewedoomd-api:dev
+```
+Expected: Serilog console output ending in `Application terminated unexpectedly` with `AgentNotifications:SharedSecret is not configured`. (A missing-DLL or "executable not found" error means the publish/entrypoint is wrong — stop and fix.)
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add src/AreWeDoomd.Api/Dockerfile; git commit -m "feat: add Api Dockerfile (multi-stage, aspnet:10.0)"
+```
+
+---
+
+### Task 3: AgentService Dockerfile
+
+**Files:**
+- Create: `src/AreWeDoomd.AgentService/Dockerfile`
+
+- [ ] **Step 1: Write the Dockerfile**
+
+```dockerfile
+# Build context must be the repository root:
+#   docker build -f src/AreWeDoomd.AgentService/Dockerfile .
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy project files first so 'dotnet restore' is layer-cached
+COPY src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj src/AreWeDoomd.AgentService/
+COPY src/AreWeDoomd.ActivityNotifications.Contracts/AreWeDoomd.ActivityNotifications.Contracts.csproj src/AreWeDoomd.ActivityNotifications.Contracts/
+RUN dotnet restore src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj
+
+COPY src/ src/
+RUN dotnet publish src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj -c Release -o /app/publish --no-restore
+
+# Plain worker host, not a web app -> runtime image, no EXPOSE
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "AreWeDoomd.AgentService.dll"]
+```
+
+- [ ] **Step 2: Build the image**
+
+```powershell
+docker build -f src/AreWeDoomd.AgentService/Dockerfile -t arewedoomd-agent:dev .
+```
+Expected: build succeeds, image tagged `arewedoomd-agent:dev`.
+
+- [ ] **Step 3: Verify the Prompts files made it into the image**
+
+```powershell
+docker run --rm --entrypoint ls arewedoomd-agent:dev /app/Prompts
+```
+Expected: lists the `.md` prompt files (same names as `src/AreWeDoomd.AgentService/Prompts/`). Empty output or "No such file or directory" means the `.dockerignore` or publish step is wrong — stop and fix (check that `.dockerignore` uses `*.md`, not `**/*.md`).
+
+- [ ] **Step 4: Commit**
+
+```powershell
+git add src/AreWeDoomd.AgentService/Dockerfile; git commit -m "feat: add AgentService Dockerfile (multi-stage, runtime:10.0)"
+```
+
+---
+
+### Task 4: Compose file and environment template
+
+**Files:**
+- Create: `docker-compose.yml`
+- Create: `.env.example`
+- Create: `.env` (local only — never committed)
+
+- [ ] **Step 1: Write `docker-compose.yml`**
+
+```yaml
+# Local development environment.
+#   1. Copy .env.example to .env and fill in values.
+#   2. docker compose up --build
+# The IDE workflow (dotnet run) is unaffected by this file.
+services:
+  api:
+    build:
+      context: .
+      dockerfile: src/AreWeDoomd.Api/Dockerfile
+    ports:
+      - "5188:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__AreWeDoomdSql: ${AREWEDOOMD_SQL_CONNECTION}
+      Jwt__Key: ${JWT_KEY}
+      AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
+      # SMTP is optional for local dev; add Smtp__Host etc. here when needed.
+
+  agent-service:
+    build:
+      context: .
+      dockerfile: src/AreWeDoomd.AgentService/Dockerfile
+    depends_on:
+      - api
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      # Container-to-container traffic goes via the compose service name.
+      AgentNotifications__HubUrl: http://api:8080/hubs/agent-notifications
+      AgentNotifications__ApiBaseUrl: http://api:8080
+      AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      ChatProviders__Anthropic__ApiKey: ${ANTHROPIC_API_KEY:-}
+
+  redis:
+    # Provisioned ahead of use; no app config points at it yet.
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:
+```
+
+- [ ] **Step 2: Write `.env.example`**
+
+```
+# Copy this file to .env and fill in real values. .env is git-ignored.
+
+# Connection string to your existing SQL Server (NOT containerized).
+# From inside a container, "host.docker.internal" reaches your machine.
+# Must use SQL authentication - Windows/Trusted auth does not work from Linux containers.
+AREWEDOOMD_SQL_CONNECTION=Server=host.docker.internal,1433;Database=AreWeDoomd;User Id=sa;Password=<your-password>;TrustServerCertificate=True
+
+# JWT signing key (dev value; any sufficiently long string)
+JWT_KEY=dev-signing-key-change-this-before-production-12345
+
+# Shared secret between Api and AgentService (must match on both sides;
+# compose injects the same value into both containers)
+AGENT_SHARED_SECRET=dev-agent-shared-secret-change-me
+
+# Chat provider API keys (leave empty for providers you don't use)
+GEMINI_API_KEY=
+ANTHROPIC_API_KEY=
+```
+
+- [ ] **Step 3: Create the local `.env`**
+
+Copy the template (the user fills in the real DB password/keys; for now real values may already be in user secrets — ask the user for the connection string if `dotnet user-secrets list --project src/AreWeDoomd.Api` doesn't reveal it):
+```powershell
+Copy-Item .env.example .env
+```
+Then set `AREWEDOOMD_SQL_CONNECTION` in `.env` to a working SQL-auth connection string for the existing database.
+
+- [ ] **Step 4: Validate compose interpolation**
+
+```powershell
+docker compose config
+```
+Expected: renders the full config with `.env` values substituted; exits 0. Any "variable is not set" warning means `.env` is missing a key.
+
+- [ ] **Step 5: Commit (everything except `.env`)**
+
+```powershell
+git add docker-compose.yml .env.example; git commit -m "feat: add docker compose for local dev (api, agent-service, redis)"; git status --short
+```
+Expected: `git status` does NOT list `.env`.
+
+---
+
+### Task 5: End-to-end verification (spec section "Verification")
+
+No new files — this task proves the whole stack works.
+
+- [ ] **Step 1: Bring the stack up**
+
+```powershell
+docker compose up --build -d; docker compose ps
+```
+Expected: three services (`api`, `agent-service`, `redis`) with status `Up`/`running`.
+
+- [ ] **Step 2: Api responds on localhost:5188**
+
+```powershell
+Invoke-WebRequest -Uri http://localhost:5188/openapi/v1.json -UseBasicParsing | Select-Object StatusCode
+```
+Expected: `StatusCode 200` (OpenAPI is mapped because the container runs in Development).
+
+- [ ] **Step 3: AgentService connected to the hub**
+
+```powershell
+docker compose logs agent-service --tail 50
+```
+Expected: log lines showing a successful SignalR connection to `http://api:8080/hubs/agent-notifications` and no recurring connection-failure loop. (A one-time retry at startup is fine — `depends_on` only orders container start, not app readiness.)
+
+- [ ] **Step 4: Redis answers**
+
+```powershell
+docker compose exec redis redis-cli ping
+```
+Expected output: `PONG`
+
+- [ ] **Step 5: IDE workflow still works (spec verification item 5)**
+
+```powershell
+dotnet build AreWeDoomd.Api.slnx
+```
+Expected: `Build succeeded`. (No source or appsettings files were touched, so this is a sanity check only.)
+
+- [ ] **Step 6: Tear down and final commit (if any fixes were made)**
+
+```powershell
+docker compose down
+```
+If verification required fixes to any committed file, commit them:
+```powershell
+git add -A; git status --short; git commit -m "fix: adjust container config after end-to-end verification"
+```
+(Skip the commit if the tree is clean. Confirm `.env` is never staged.)
+
+---
+
+## Self-review notes
+
+- Spec coverage: Dockerfiles (Tasks 2-3), compose with api/agent-service/redis (Task 4), `.dockerignore` + `.gitignore` (Task 1), `.env`/`.env.example` (Task 4), all five spec verification items (Task 5; container fail-fast on missing secret additionally covered in Task 2 Step 3).
+- The spec's `docs/` exclusion in `.dockerignore` is safe: no project references files under `docs/`.
+- Type/name consistency: image tags `arewedoomd-api:dev` / `arewedoomd-agent:dev` are only used within their own tasks; compose builds its own images independently.

--- a/docs/superpowers/specs/2026-06-11-containerization-design.md
+++ b/docs/superpowers/specs/2026-06-11-containerization-design.md
@@ -1,0 +1,124 @@
+# Containerization Design — Local Dev Environment
+
+**Date:** 2026-06-11
+**Status:** Approved (Approach A — full compose: apps + Redis in containers)
+
+## Goal
+
+Provide a one-command local development environment (`docker compose up --build`)
+that runs both runnable projects and Redis in containers, while keeping the
+existing `dotnet run` / IDE workflow untouched. Production deployment is out of
+scope for this phase.
+
+## Context
+
+- .NET 10 Clean Architecture solution (`AreWeDoomd.Api.slnx`).
+- Runnable projects:
+  - `src/AreWeDoomd.Api` — ASP.NET Core web app (SQL Server via EF Core,
+    SignalR hub at `/hubs/agent-notifications`, local port 5188).
+  - `src/AreWeDoomd.AgentService` — generic-host worker that connects to the
+    Api's SignalR hub and HTTP endpoints, and calls Gemini/Anthropic APIs.
+- Database: existing external SQL Server (NOT containerized). Connection
+  string key: `ConnectionStrings:AreWeDoomdSql`.
+- Redis: planned for future use. The container is provisioned now; no
+  application code or configuration consumes it yet.
+- More runnable projects are expected later; the structure must make adding
+  one cheap (one Dockerfile + one compose service block).
+
+## Files Added
+
+```
+src/AreWeDoomd.Api/Dockerfile
+src/AreWeDoomd.AgentService/Dockerfile
+.dockerignore
+docker-compose.yml
+.env.example          (committed)
+.env                  (git-ignored; add to .gitignore)
+```
+
+## Dockerfiles
+
+Multi-stage builds. Build context is the **repo root** so project references
+resolve.
+
+- Build stage: `mcr.microsoft.com/dotnet/sdk:10.0`. Copy `*.csproj` files
+  first and run `dotnet restore` for layer caching, then copy sources and
+  `dotnet publish -c Release`.
+- Runtime stage:
+  - Api: `mcr.microsoft.com/dotnet/aspnet:10.0` (listens on container port
+    8080, the image default).
+  - AgentService: `mcr.microsoft.com/dotnet/runtime:10.0` (plain host, not a
+    web app). `Prompts/**/*.md` content files flow through publish
+    automatically.
+
+`.dockerignore` excludes `bin/`, `obj/`, `.git/`, `.claude/`, `docs/`,
+`postman/`, `tests/` build artifacts.
+
+## docker-compose.yml
+
+Three services on the default compose network:
+
+### `api`
+- Builds from `src/AreWeDoomd.Api/Dockerfile`, context `.`.
+- Ports: `5188:8080`.
+- Environment (values sourced from `.env`):
+  - `ConnectionStrings__AreWeDoomdSql` — points at the external SQL Server.
+    For a SQL Server on the host machine, use `host.docker.internal` as the
+    server name.
+  - `Jwt__Key`
+  - `AgentNotifications__SharedSecret`
+  - `Smtp__*` (optional)
+  - `ASPNETCORE_ENVIRONMENT=Development`
+
+### `agent-service`
+- Builds from `src/AreWeDoomd.AgentService/Dockerfile`, context `.`.
+- `depends_on: api`.
+- Environment:
+  - `AgentNotifications__HubUrl=http://api:8080/hubs/agent-notifications`
+  - `AgentNotifications__ApiBaseUrl=http://api:8080`
+  - `AgentNotifications__SharedSecret` (same value as the Api's, from `.env`)
+  - `ChatProviders__Gemini__ApiKey` / `ChatProviders__Anthropic__ApiKey`
+    (from `.env`)
+  - `DOTNET_ENVIRONMENT=Development`
+
+### `redis`
+- Image `redis:7-alpine`.
+- Named volume for persistence.
+- Ports: `6379:6379` (exposed to host for tooling/inspection).
+- No app configuration references it yet (deliberate — YAGNI until the code
+  uses it).
+
+## Configuration & Secrets
+
+- `.env.example` documents every variable the compose file reads, with safe
+  placeholder values and a comment per variable.
+- `.env` is git-ignored and holds real local values (DB connection string,
+  API keys, secrets).
+- Container configuration is applied exclusively via environment variables
+  (standard `Section__Key` convention), so `appsettings*.json` files stay
+  unchanged and IDE runs are unaffected.
+
+## Error Handling / Resilience
+
+- AgentService already has SignalR reconnect/retry logic; `depends_on`
+  ordering plus that logic covers the api/agent startup race.
+- The Api fails fast on a missing/invalid DB connection string; the required
+  variables are documented in `.env.example`.
+- Resilience hardening of the AI provider subsystem is a deliberate later
+  phase and out of scope here.
+
+## Verification
+
+1. `docker compose up --build` succeeds.
+2. Api responds on `http://localhost:5188` (e.g. Scalar/OpenAPI endpoint or a
+   known endpoint returns non-5xx).
+3. AgentService logs show a successful hub connection to the Api.
+4. `docker exec <redis> redis-cli ping` returns `PONG`.
+5. `dotnet run` from the IDE still works unchanged.
+
+## Out of Scope
+
+- Production images, registries, CI publishing.
+- SQL Server container.
+- Wiring Redis into application code.
+- Aspire or other orchestrators.

--- a/src/AreWeDoomd.AgentService/Dockerfile
+++ b/src/AreWeDoomd.AgentService/Dockerfile
@@ -9,6 +9,8 @@ COPY src/AreWeDoomd.ActivityNotifications.Contracts/AreWeDoomd.ActivityNotificat
 RUN dotnet restore src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj
 
 COPY src/ src/
+# Prompts/**/*.md and appsettings.json reach the publish output via the
+# csproj's CopyToOutputDirectory items — keep them out of .dockerignore.
 RUN dotnet publish src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj -c Release -o /app/publish --no-restore
 
 # Plain worker host, not a web app -> runtime image, no EXPOSE

--- a/src/AreWeDoomd.AgentService/Dockerfile
+++ b/src/AreWeDoomd.AgentService/Dockerfile
@@ -1,0 +1,18 @@
+# Build context must be the repository root:
+#   docker build -f src/AreWeDoomd.AgentService/Dockerfile .
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy project files first so 'dotnet restore' is layer-cached
+COPY src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj src/AreWeDoomd.AgentService/
+COPY src/AreWeDoomd.ActivityNotifications.Contracts/AreWeDoomd.ActivityNotifications.Contracts.csproj src/AreWeDoomd.ActivityNotifications.Contracts/
+RUN dotnet restore src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj
+
+COPY src/ src/
+RUN dotnet publish src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj -c Release -o /app/publish --no-restore
+
+# Plain worker host, not a web app -> runtime image, no EXPOSE
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "AreWeDoomd.AgentService.dll"]

--- a/src/AreWeDoomd.Api/Dockerfile
+++ b/src/AreWeDoomd.Api/Dockerfile
@@ -1,0 +1,21 @@
+# Build context must be the repository root:
+#   docker build -f src/AreWeDoomd.Api/Dockerfile .
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+# Copy project files first so 'dotnet restore' is layer-cached
+COPY src/AreWeDoomd.Api/AreWeDoomd.Api.csproj src/AreWeDoomd.Api/
+COPY src/AreWeDoomd.Application/AreWeDoomd.Application.csproj src/AreWeDoomd.Application/
+COPY src/AreWeDoomd.Domain/AreWeDoomd.Domain.csproj src/AreWeDoomd.Domain/
+COPY src/AreWeDoomd.Infrastructure/AreWeDoomd.Infrastructure.csproj src/AreWeDoomd.Infrastructure/
+COPY src/AreWeDoomd.ActivityNotifications.Contracts/AreWeDoomd.ActivityNotifications.Contracts.csproj src/AreWeDoomd.ActivityNotifications.Contracts/
+RUN dotnet restore src/AreWeDoomd.Api/AreWeDoomd.Api.csproj
+
+COPY src/ src/
+RUN dotnet publish src/AreWeDoomd.Api/AreWeDoomd.Api.csproj -c Release -o /app/publish --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "AreWeDoomd.Api.dll"]


### PR DESCRIPTION
## Summary

Adds a one-command local development environment: `docker compose up --build`
starts the Api, the AgentService, and Redis in containers. The existing IDE
workflow (`dotnet run` / F5) is completely untouched — no application code or
appsettings files changed.

- **`src/AreWeDoomd.Api/Dockerfile`** — multi-stage build (sdk:10.0 → aspnet:10.0), layer-cached restore, listens on container port 8080, published on host port **5188** (same port as `dotnet run`, so Postman collections and the frontend keep working)
- **`src/AreWeDoomd.AgentService/Dockerfile`** — multi-stage build onto the slim `runtime:10.0` image (plain worker, no web server); `Prompts/**/*.md` flow into the image via the csproj content items
- **`docker-compose.yml`** — wires the three services; agent-service reaches the api via `http://api:8080` on the compose network and only starts once the api passes a TCP healthcheck (the agent's own SignalR retry loop still covers reconnects after crashes/restarts)
- **`.env.example`** — documents every variable the compose file reads; copy to `.env` (git-ignored) and fill in real values
- **`.dockerignore`** / `.gitignore` — lean build context; `.env` can never be committed
- **Redis** runs from `redis:7-alpine` with a persistent volume, exposed on 6379. Nothing consumes it yet — provisioned ahead of the planned caching work.

Design spec: `docs/superpowers/specs/2026-06-11-containerization-design.md`
Implementation plan: `docs/superpowers/plans/2026-06-11-containerization.md`

## Notes for reviewers

- The database stays **external** (Azure SQL / any SQL-auth server). Containers are Linux, so Windows/Trusted authentication doesn't work — connection strings must use SQL logins (documented in `.env.example`).
- The agent-service fails fast at startup without a `GEMINI_API_KEY` — that's its existing options validation, not a containerization change.
- Adding a future runnable project = copy a Dockerfile + add one compose service block.

## Test plan

- [x] Both images build from a clean context
- [x] `docker compose up --build`: all three services start; api waits for healthcheck before agent-service starts
- [x] Api responds 200 on `http://localhost:5188/openapi/v1.json`
- [x] AgentService logs `Connected to agent notification hub at http://api:8080/...` (first try, no retry warnings)
- [x] `docker compose exec redis redis-cli ping` → `PONG`
- [x] `dotnet build` and unit tests (112/112) unaffected
- [x] `.env` confirmed git-ignored and absent from all history
- [ ] Reviewer: copy `.env.example` → `.env`, fill in values, `docker compose up --build`