### PR TITLE
Feat/signalr redis backplane

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build:
       context: .
       dockerfile: src/AreWeDoomd.Api/Dockerfile
+    depends_on:
+      - redis
     ports:
       - "5188:8080"
     environment:
@@ -14,6 +16,10 @@ services:
       ConnectionStrings__AreWeDoomdSql: ${AREWEDOOMD_SQL_CONNECTION}
       Jwt__Key: ${JWT_KEY}
       AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
+      # Enables the SignalR Redis backplane for horizontal scaling. Fixed
+      # internal address of the compose `redis` service below; no .env value
+      # needed. Leave unset (locally / single-instance) to run in-memory.
+      ConnectionStrings__Redis: redis:6379
       # SMTP is optional for local dev; add Smtp__Host etc. here when needed.
     healthcheck:
       # "Is the port accepting connections?" via bash's built-in /dev/tcp —

--- a/docs/superpowers/plans/2026-06-13-signalr-redis-backplane.md
+++ b/docs/superpowers/plans/2026-06-13-signalr-redis-backplane.md
@@ -1,0 +1,301 @@
+# SignalR Redis Backplane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a conditional Redis backplane to SignalR so the API can scale horizontally — hub messages fan out across instances only when a Redis connection string is configured.
+
+**Architecture:** A small extension method on `IServiceCollection` performs the SignalR registration (MessagePack protocol, unchanged) and chains `AddStackExchangeRedis` only when `ConnectionStrings:Redis` is non-empty. `Program.cs` calls the extension and logs which mode is active. Extracting the logic into an extension method (a small, justified deviation from the inline snippet in the spec) makes the conditional registration unit-testable without a live Redis and satisfies the repo's one-class-per-file convention.
+
+**Tech Stack:** .NET 10, ASP.NET Core SignalR, `Microsoft.AspNetCore.SignalR.StackExchangeRedis` 10.0.9, StackExchange.Redis, xUnit + Shouldly.
+
+---
+
+## File Structure
+
+- **Create** `src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs` — extension method `AddRealtimeSignalR(this IServiceCollection, string? redisConnectionString)` that owns SignalR + MessagePack + conditional backplane registration.
+- **Modify** `src/AreWeDoomd.Api/AreWeDoomd.Api.csproj` — add the StackExchangeRedis package.
+- **Modify** `src/AreWeDoomd.Api/Program.cs:71-76` — replace the inline `AddSignalR().AddMessagePackProtocol(...)` block with a call to the extension + startup log line.
+- **Create** `tests/AreWeDoomd.UnitTests/Realtime/SignalRRegistrationExtensionsTests.cs` — DI-wiring unit tests (no live Redis).
+- **Modify** `docker-compose.yml:12-16` — add `ConnectionStrings__Redis` to the `api` service and `depends_on: redis`.
+
+---
+
+## Task 1: Add the StackExchange.Redis backplane package
+
+**Files:**
+- Modify: `src/AreWeDoomd.Api/AreWeDoomd.Api.csproj`
+
+- [ ] **Step 1: Add the package reference**
+
+In `src/AreWeDoomd.Api/AreWeDoomd.Api.csproj`, add this line to the first `<ItemGroup>` (the one containing the other `Microsoft.AspNetCore.*` packages), keeping alphabetical-ish ordering next to the other SignalR package:
+
+```xml
+<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
+```
+
+- [ ] **Step 2: Restore and build to verify the package resolves**
+
+Run: `dotnet build src/AreWeDoomd.Api/AreWeDoomd.Api.csproj`
+Expected: Build succeeds (the new package downloads and restores). No code uses it yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/AreWeDoomd.Api/AreWeDoomd.Api.csproj
+git commit -m "build: add SignalR StackExchangeRedis backplane package"
+```
+
+---
+
+## Task 2: Conditional registration extension method (TDD)
+
+**Files:**
+- Create: `tests/AreWeDoomd.UnitTests/Realtime/SignalRRegistrationExtensionsTests.cs`
+- Create: `src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs`
+
+> **Why assert by descriptor, not by resolved instance:** `AddSignalR` registers the open generic `HubLifetimeManager<>` via `TryAddSingleton` → `DefaultHubLifetimeManager<>`. `AddStackExchangeRedis` registers it again via `AddSingleton` → `RedisHubLifetimeManager<>`, so when Redis is configured the *last* descriptor for `HubLifetimeManager<>` wins. Inspecting the `IServiceCollection` descriptors checks the effective registration **without** building a provider or opening a Redis connection. `RedisHubLifetimeManager<>` is an internal type in the package, so we assert on its type **name** rather than referencing the type directly.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/AreWeDoomd.UnitTests/Realtime/SignalRRegistrationExtensionsTests.cs`:
+
+```csharp
+using AreWeDoomd.Api.Realtime;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Realtime;
+
+public sealed class SignalRRegistrationExtensionsTests
+{
+    [Fact]
+    public void AddRealtimeSignalR_WhenNoRedisConfigured_UsesDefaultHubLifetimeManager()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddRealtimeSignalR(redisConnectionString: null);
+
+        var descriptor = services.Last(d => d.ServiceType == typeof(HubLifetimeManager<>));
+        descriptor.ImplementationType.ShouldBe(typeof(DefaultHubLifetimeManager<>));
+    }
+
+    [Fact]
+    public void AddRealtimeSignalR_WhenWhitespaceRedisConfigured_UsesDefaultHubLifetimeManager()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddRealtimeSignalR(redisConnectionString: "   ");
+
+        var descriptor = services.Last(d => d.ServiceType == typeof(HubLifetimeManager<>));
+        descriptor.ImplementationType.ShouldBe(typeof(DefaultHubLifetimeManager<>));
+    }
+
+    [Fact]
+    public void AddRealtimeSignalR_WhenRedisConfigured_UsesRedisHubLifetimeManager()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // abortConnect=false ensures no eager connection even if a provider were built;
+        // this test only inspects descriptors, so nothing connects regardless.
+        services.AddRealtimeSignalR("localhost:6379,abortConnect=false");
+
+        var descriptor = services.Last(d => d.ServiceType == typeof(HubLifetimeManager<>));
+        descriptor.ImplementationType.ShouldNotBeNull();
+        descriptor.ImplementationType!.Name.ShouldStartWith("RedisHubLifetimeManager");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test tests/AreWeDoomd.UnitTests/AreWeDoomd.UnitTests.csproj --filter "FullyQualifiedName~SignalRRegistrationExtensionsTests"`
+Expected: FAIL — compile error, `AddRealtimeSignalR` does not exist on `IServiceCollection`.
+
+- [ ] **Step 3: Write the extension method**
+
+Create `src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs`:
+
+```csharp
+using MessagePack;
+using StackExchange.Redis;
+
+namespace AreWeDoomd.Api.Realtime;
+
+public static class SignalRRegistrationExtensions
+{
+    // Registers SignalR with the MessagePack protocol. When a Redis connection
+    // string is supplied, a StackExchange.Redis backplane is added so hub
+    // messages fan out across multiple API instances (horizontal scaling).
+    // When the connection string is null/empty, SignalR runs in-memory.
+    public static IServiceCollection AddRealtimeSignalR(
+        this IServiceCollection services,
+        string? redisConnectionString)
+    {
+        var signalRBuilder = services.AddSignalR()
+            .AddMessagePackProtocol(opts =>
+            {
+                opts.SerializerOptions = MessagePackSerializerOptions.Standard
+                    .WithResolver(MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            });
+
+        if (!string.IsNullOrWhiteSpace(redisConnectionString))
+        {
+            signalRBuilder.AddStackExchangeRedis(redisConnectionString, options =>
+            {
+                // Isolates this app's pub/sub channels so a Redis instance shared
+                // with other workloads does not cross-talk.
+                options.Configuration.ChannelPrefix = RedisChannel.Literal("awd");
+            });
+        }
+
+        return services;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `dotnet test tests/AreWeDoomd.UnitTests/AreWeDoomd.UnitTests.csproj --filter "FullyQualifiedName~SignalRRegistrationExtensionsTests"`
+Expected: PASS — all 3 tests green.
+
+> If `RedisChannel.Literal` does not resolve, the installed StackExchange.Redis exposes `ChannelPrefix` as a string instead; in that case assign `options.Configuration.ChannelPrefix = "awd";`. Re-run the tests after adjusting.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs tests/AreWeDoomd.UnitTests/Realtime/SignalRRegistrationExtensionsTests.cs
+git commit -m "feat: add conditional SignalR Redis backplane registration"
+```
+
+---
+
+## Task 3: Wire Program.cs to the extension method
+
+**Files:**
+- Modify: `src/AreWeDoomd.Api/Program.cs:71-76`
+
+- [ ] **Step 1: Replace the inline SignalR registration**
+
+In `src/AreWeDoomd.Api/Program.cs`, replace this existing block (currently at lines 71-76):
+
+```csharp
+    builder.Services.AddSignalR()
+        .AddMessagePackProtocol(opts =>
+        {
+            opts.SerializerOptions = MessagePackSerializerOptions.Standard
+                .WithResolver(MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+        });
+```
+
+with:
+
+```csharp
+    var redisConnectionString = builder.Configuration.GetConnectionString("Redis");
+    builder.Services.AddRealtimeSignalR(redisConnectionString);
+
+    if (!string.IsNullOrWhiteSpace(redisConnectionString))
+    {
+        Log.Information("SignalR Redis backplane enabled.");
+    }
+    else
+    {
+        Log.Information("SignalR running in-memory (no Redis backplane configured).");
+    }
+```
+
+The `using AreWeDoomd.Api.Realtime;` directive is already present at the top of `Program.cs`, so no new using is needed. The `MessagePack` using at the top is now only used by the extension method — leave the `using MessagePack;` line in place only if other code in `Program.cs` still references it; if the build warns it's unused, remove `using MessagePack;` from `Program.cs`.
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build src/AreWeDoomd.Api/AreWeDoomd.Api.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run the realtime integration tests to confirm in-memory behavior is unchanged**
+
+These tests use `AgentHubTestFactory`, which sets only `ConnectionStrings:AreWeDoomdSql` (never `Redis`), so the in-memory path must still pass.
+
+Run: `dotnet test tests/AreWeDoomd.IntegrationTests/AreWeDoomd.IntegrationTests.csproj --filter "FullyQualifiedName~Realtime"`
+Expected: PASS for `UserNotificationHubTests` and `AgentNotificationHubTests` (any pre-existing unrelated failures noted in project memory are out of scope — confirm the Realtime hub tests specifically pass).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/AreWeDoomd.Api/Program.cs
+git commit -m "feat: enable SignalR Redis backplane via configuration in Program.cs"
+```
+
+---
+
+## Task 4: Wire docker-compose and document the config key
+
+**Files:**
+- Modify: `docker-compose.yml:12-16` (api service `environment`) and `docker-compose.yml:5-26` (api `depends_on`)
+
+- [ ] **Step 1: Point the api service at the existing redis service**
+
+In `docker-compose.yml`, in the `api` service's `environment` block, add a line after `AgentNotifications__SharedSecret`:
+
+```yaml
+      # Enables the SignalR Redis backplane for horizontal scaling. Fixed
+      # internal address of the compose `redis` service below; no .env value
+      # needed. Leave unset (locally / single-instance) to run in-memory.
+      ConnectionStrings__Redis: redis:6379
+```
+
+- [ ] **Step 2: Add a depends_on so api starts after redis**
+
+In `docker-compose.yml`, add a `depends_on` to the `api` service (it currently has none). Place it directly under the `build:` block, before `ports:`:
+
+```yaml
+    depends_on:
+      - redis
+```
+
+- [ ] **Step 3: Validate the compose file**
+
+Run: `docker compose config`
+Expected: Prints the resolved configuration with no errors; the `api` service shows `ConnectionStrings__Redis: redis:6379` and a `redis` dependency.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "chore: wire SignalR Redis backplane in docker-compose"
+```
+
+---
+
+## Task 5: Full verification
+
+- [ ] **Step 1: Build the whole solution**
+
+Run: `dotnet build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 2: Run the unit tests**
+
+Run: `dotnet test tests/AreWeDoomd.UnitTests/AreWeDoomd.UnitTests.csproj`
+Expected: PASS, including the 3 new `SignalRRegistrationExtensionsTests`.
+
+- [ ] **Step 3: Run the realtime integration tests**
+
+Run: `dotnet test tests/AreWeDoomd.IntegrationTests/AreWeDoomd.IntegrationTests.csproj --filter "FullyQualifiedName~Realtime"`
+Expected: PASS — in-memory hub behavior unchanged.
+
+- [ ] **Step 4 (optional, manual multi-instance check — requires Docker):**
+
+Out of scope for automated tests, per the spec. To verify fan-out manually: bring up compose with two `api` replicas against the shared `redis`, connect a SignalR client to each replica, publish a notification, and confirm both clients receive it.
+
+---
+
+## Self-Review Notes (addressed)
+
+- **Spec coverage:** package (Task 1), conditional registration with `ConnectionStrings:Redis` + `ChannelPrefix` + MessagePack preserved (Task 2), startup logging (Task 3), docker-compose wiring (Task 4), in-memory tests unaffected (Tasks 3 & 5). Documentation of the key is covered by the inline compose comment in Task 4 Step 1.
+- **Deviation from spec:** the spec showed the conditional registration inline in `Program.cs`; this plan extracts it to `AddRealtimeSignalR` for testability and one-class-per-file compliance. Behavior is identical.
+- **Type consistency:** `AddRealtimeSignalR(IServiceCollection, string?)` is defined in Task 2 and called identically in Task 3. `ConnectionStrings:Redis` / env `ConnectionStrings__Redis` is used consistently across Tasks 3 and 4.
+- **Fallback noted:** `RedisChannel.Literal` vs string `ChannelPrefix` handled by the note in Task 2 Step 4.

--- a/docs/superpowers/specs/2026-06-13-signalr-redis-backplane-design.md
+++ b/docs/superpowers/specs/2026-06-13-signalr-redis-backplane-design.md
@@ -1,0 +1,138 @@
+# SignalR Redis Backplane — Design
+
+**Date:** 2026-06-13
+**Status:** Approved
+
+## Goal
+
+Enable horizontal scaling of the API by adding a Redis backplane to SignalR, so
+that hub messages (notifications) fan out across multiple API instances. A client
+connected to instance A must receive a message published from instance B.
+
+## Constraints
+
+- The backplane must be **conditional**: enabled only when a Redis connection
+  string is configured. Local IDE development (`dotnet run`), the in-memory
+  integration tests, and single-instance deployments must continue to work with
+  **zero** Redis dependency.
+- Match existing repository conventions (config keys, package versions, inline
+  `Program.cs` composition style).
+- No changes to the hubs themselves or to the AgentService (which is a hub
+  *client*, not a server).
+
+## Existing Context
+
+- Two hubs: `AgentNotificationHub` (`/hubs/agent-notifications`) and
+  `UserNotificationHub`, registered in `src/AreWeDoomd.Api/Program.cs`.
+- SignalR is registered at `Program.cs:71` with the MessagePack protocol.
+- `docker-compose.yml` already contains a `redis:7-alpine` service, provisioned
+  ahead of use; no app config currently points at it.
+- Target framework `net10.0`; ASP.NET Core packages at `10.0.9`.
+- Config follows the `ConnectionStrings:AreWeDoomdSql` convention (env var
+  `ConnectionStrings__AreWeDoomdSql`).
+
+## Components
+
+### 1. Package reference
+
+Add to `src/AreWeDoomd.Api/AreWeDoomd.Api.csproj`:
+
+```xml
+<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
+```
+
+Version chosen to match the other ASP.NET Core packages already in the project.
+
+### 2. Conditional registration (`Program.cs`)
+
+Config key: `ConnectionStrings:Redis` (env var `ConnectionStrings__Redis`),
+matching the existing `ConnectionStrings:AreWeDoomdSql` convention.
+
+Read the connection string, build the SignalR builder once (preserving the
+existing MessagePack configuration), and chain the backplane only when the
+connection string is non-empty:
+
+```csharp
+var redisConnectionString = builder.Configuration.GetConnectionString("Redis");
+
+var signalRBuilder = builder.Services.AddSignalR()
+    .AddMessagePackProtocol(opts =>
+    {
+        opts.SerializerOptions = MessagePackSerializerOptions.Standard
+            .WithResolver(MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+    });
+
+if (!string.IsNullOrWhiteSpace(redisConnectionString))
+{
+    signalRBuilder.AddStackExchangeRedis(redisConnectionString, options =>
+    {
+        options.Configuration.ChannelPrefix = RedisChannel.Literal("awd");
+    });
+    Log.Information("SignalR Redis backplane enabled.");
+}
+else
+{
+    Log.Information("SignalR running in-memory (no Redis backplane configured).");
+}
+```
+
+Notes:
+- `ChannelPrefix` isolates this app's pub/sub channels so a Redis instance shared
+  with other workloads (e.g. caching) does not cross-talk.
+- In StackExchange.Redis 2.x, `ChannelPrefix` is a `RedisChannel`, so it requires
+  `RedisChannel.Literal(...)` rather than a bare string. The exact type/usage will
+  be confirmed against the package at implementation time.
+- The MessagePack configuration is unchanged. The backplane uses its own
+  server-to-server serialization, independent of the client wire protocol, so
+  there is no conflict.
+- `RedisChannel` lives in the `StackExchange.Redis` namespace; the appropriate
+  `using` will be added.
+
+### 3. docker-compose wiring
+
+Add to the `api` service `environment` in `docker-compose.yml`, pointing at the
+existing `redis` service:
+
+```yaml
+ConnectionStrings__Redis: redis:6379
+```
+
+Optionally add `redis` to the `api` service's `depends_on`. The `agent-service`
+requires no change — it connects to the hub as a client.
+
+### 4. Documentation
+
+Add a note to `.env.example` (and/or the containerization docs) explaining:
+set `ConnectionStrings__Redis` to enable the SignalR backplane for multi-instance
+deployments; leave it unset for single-instance deployments and local dev.
+
+## Data Flow
+
+1. A message is published on instance A via `IUserHubSender` / `IAgentHubSender`.
+2. SignalR's Redis backplane publishes it to the Redis pub/sub channel
+   (prefixed `awd`).
+3. All API instances subscribed to that channel receive it and deliver to their
+   locally connected clients.
+4. The client connected to instance B receives the message even though it
+   originated on instance A.
+
+## Testing
+
+- **In-memory integration tests** (`tests/AreWeDoomd.IntegrationTests`): the
+  `WebApplicationFactory`-based test host does not set `ConnectionStrings:Redis`,
+  so the backplane branch is skipped and the hubs run in-memory exactly as today.
+  Confirm the test factory does not inherit a Redis connection string from any
+  shared configuration source.
+- **Local IDE dev**: `appsettings.Development.json` does not set the key; runs
+  in-memory.
+- **Manual multi-instance verification** (out of scope for automated tests):
+  run two API instances against the docker-compose `redis`, connect a client to
+  each, and confirm a message published on one is received on the other.
+
+## Out of Scope
+
+- Redis-backed sticky-session / connection store: the backplane handles fan-out;
+  SignalR's default reconnect behavior is sufficient.
+- Redis resilience / retry policy: consistent with the deliberate "resilience is
+  a later phase" stance for the realtime subsystem.
+- Any changes to the hub classes or the AgentService client.

--- a/src/AreWeDoomd.Api/AreWeDoomd.Api.csproj
+++ b/src/AreWeDoomd.Api/AreWeDoomd.Api.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/AreWeDoomd.Api/Program.cs
+++ b/src/AreWeDoomd.Api/Program.cs
@@ -1,4 +1,3 @@
-using MessagePack;
 using AreWeDoomd.Api.Auth;
 using AreWeDoomd.Api.Common.Errors;
 using AreWeDoomd.Api.Notifications;
@@ -68,12 +67,17 @@ try
 
     builder.Services.Configure<AgentNotificationsOptions>(
         builder.Configuration.GetSection(AgentNotificationsOptions.SectionName));
-    builder.Services.AddSignalR()
-        .AddMessagePackProtocol(opts =>
-        {
-            opts.SerializerOptions = MessagePackSerializerOptions.Standard
-                .WithResolver(MessagePack.Resolvers.ContractlessStandardResolver.Instance);
-        });
+    var redisConnectionString = builder.Configuration.GetConnectionString("Redis");
+    builder.Services.AddRealtimeSignalR(redisConnectionString);
+
+    if (!string.IsNullOrWhiteSpace(redisConnectionString))
+    {
+        Log.Information("SignalR Redis backplane enabled.");
+    }
+    else
+    {
+        Log.Information("SignalR running in-memory (no Redis backplane configured).");
+    }
     builder.Services.AddSingleton<IAgentHubSender, AgentHubSender>();
     builder.Services.AddSingleton<IUserHubSender, UserHubSender>();
     builder.Services.AddSingleton<IActivityNotificationQueue, ChannelActivityNotificationQueue>();

--- a/src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs
+++ b/src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs
@@ -24,9 +24,10 @@ public static class SignalRRegistrationExtensions
         {
             signalRBuilder.AddStackExchangeRedis(redisConnectionString, options =>
             {
-                // Isolates this app's pub/sub channels so a Redis instance shared
-                // with other workloads does not cross-talk.
-                options.Configuration.ChannelPrefix = RedisChannel.Literal("awd");
+                // Isolates this app's SignalR pub/sub channels so a Redis instance
+                // shared with other workloads (or other AWD services) does not
+                // cross-talk.
+                options.Configuration.ChannelPrefix = RedisChannel.Literal("awd:signalr");
             });
         }
 

--- a/src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs
+++ b/src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs
@@ -1,0 +1,35 @@
+using MessagePack;
+using StackExchange.Redis;
+
+namespace AreWeDoomd.Api.Realtime;
+
+public static class SignalRRegistrationExtensions
+{
+    // Registers SignalR with the MessagePack protocol. When a Redis connection
+    // string is supplied, a StackExchange.Redis backplane is added so hub
+    // messages fan out across multiple API instances (horizontal scaling).
+    // When the connection string is null/empty, SignalR runs in-memory.
+    public static IServiceCollection AddRealtimeSignalR(
+        this IServiceCollection services,
+        string? redisConnectionString)
+    {
+        var signalRBuilder = services.AddSignalR()
+            .AddMessagePackProtocol(opts =>
+            {
+                opts.SerializerOptions = MessagePackSerializerOptions.Standard
+                    .WithResolver(MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            });
+
+        if (!string.IsNullOrWhiteSpace(redisConnectionString))
+        {
+            signalRBuilder.AddStackExchangeRedis(redisConnectionString, options =>
+            {
+                // Isolates this app's pub/sub channels so a Redis instance shared
+                // with other workloads does not cross-talk.
+                options.Configuration.ChannelPrefix = RedisChannel.Literal("awd");
+            });
+        }
+
+        return services;
+    }
+}

--- a/tests/AreWeDoomd.UnitTests/Common/Behaviors/LoggingPipelineBehaviorTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Common/Behaviors/LoggingPipelineBehaviorTests.cs
@@ -26,7 +26,7 @@ public sealed class LoggingPipelineBehaviorTests
         var behavior = new LoggingPipelineBehavior<TestRequest, string>(logger.Object);
         var request = new TestRequest("hello");
 
-        var result = await behavior.Handle(request, () => Task.FromResult("world"), CancellationToken.None);
+        var result = await behavior.Handle(request, _ => Task.FromResult("world"), CancellationToken.None);
 
         result.ShouldBe("world");
     }
@@ -37,7 +37,7 @@ public sealed class LoggingPipelineBehaviorTests
         var logger = BuildLogger<TestRequest>();
         var behavior = new LoggingPipelineBehavior<TestRequest, string>(logger.Object);
 
-        await behavior.Handle(new TestRequest("x"), () => Task.FromResult("ok"), CancellationToken.None);
+        await behavior.Handle(new TestRequest("x"), _ => Task.FromResult("ok"), CancellationToken.None);
 
         VerifyLogContains(logger, LogLevel.Information, "Executing", Times.Once());
         VerifyLogContains(logger, LogLevel.Information, "Executed", Times.Once());
@@ -49,7 +49,7 @@ public sealed class LoggingPipelineBehaviorTests
         var logger = BuildLogger<SensitiveRequest>();
         var behavior = new LoggingPipelineBehavior<SensitiveRequest, string>(logger.Object);
 
-        await behavior.Handle(new SensitiveRequest("secret123"), () => Task.FromResult("ok"), CancellationToken.None);
+        await behavior.Handle(new SensitiveRequest("secret123"), _ => Task.FromResult("ok"), CancellationToken.None);
 
         VerifyLogContains(logger, LogLevel.Information, "[REDACTED]", Times.Once());
     }
@@ -63,7 +63,7 @@ public sealed class LoggingPipelineBehaviorTests
 
         var act = async () => await behavior.Handle(
             new TestRequest("x"),
-            () => throw exception,
+            _ => throw exception,
             CancellationToken.None);
 
         await act.ShouldThrowAsync<InvalidOperationException>();

--- a/tests/AreWeDoomd.UnitTests/Realtime/SignalRRegistrationExtensionsTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Realtime/SignalRRegistrationExtensionsTests.cs
@@ -1,0 +1,49 @@
+using AreWeDoomd.Api.Realtime;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Realtime;
+
+public sealed class SignalRRegistrationExtensionsTests
+{
+    [Fact]
+    public void AddRealtimeSignalR_WhenNoRedisConfigured_UsesDefaultHubLifetimeManager()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddRealtimeSignalR(redisConnectionString: null);
+
+        var descriptor = services.Last(d => d.ServiceType == typeof(HubLifetimeManager<>));
+        descriptor.ImplementationType.ShouldBe(typeof(DefaultHubLifetimeManager<>));
+    }
+
+    [Fact]
+    public void AddRealtimeSignalR_WhenWhitespaceRedisConfigured_UsesDefaultHubLifetimeManager()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddRealtimeSignalR(redisConnectionString: "   ");
+
+        var descriptor = services.Last(d => d.ServiceType == typeof(HubLifetimeManager<>));
+        descriptor.ImplementationType.ShouldBe(typeof(DefaultHubLifetimeManager<>));
+    }
+
+    [Fact]
+    public void AddRealtimeSignalR_WhenRedisConfigured_UsesRedisHubLifetimeManager()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // abortConnect=false ensures no eager connection even if a provider were built;
+        // this test only inspects descriptors, so nothing connects regardless.
+        services.AddRealtimeSignalR("localhost:6379,abortConnect=false");
+
+        var descriptor = services.Last(d => d.ServiceType == typeof(HubLifetimeManager<>));
+        descriptor.ImplementationType.ShouldNotBeNull();
+        descriptor.ImplementationType!.Name.ShouldStartWith("RedisHubLifetimeManager");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Redis backplane to SignalR so the API can run as multiple instances and
still deliver realtime notifications correctly — a message published from one
instance reaches clients connected to any other instance.

The backplane is **conditional**: it activates only when a `ConnectionStrings:Redis`
value is configured. With it unset (local `dotnet run`, unit/integration tests,
single-instance deploys), SignalR runs fully in-memory with zero Redis dependency.

## What changed

- **Package:** add `Microsoft.AspNetCore.SignalR.StackExchangeRedis` (10.0.9).
- **`AddRealtimeSignalR(IServiceCollection, string?)`** extension
  (`src/AreWeDoomd.Api/Realtime/SignalRRegistrationExtensions.cs`): owns the SignalR
  + MessagePack registration and conditionally chains `AddStackExchangeRedis`. Uses a
  `awd:signalr` channel prefix so the app's pub/sub is isolated on a shared Redis.
- **`Program.cs`:** reads `ConnectionStrings:Redis`, calls the extension, and logs
  whether the backplane is enabled or in-memory at startup. MessagePack config is
  preserved verbatim — the in-memory path is byte-for-byte unchanged.
- **`docker-compose.yml`:** points the `api` service at the existing `redis` service
  (`ConnectionStrings__Redis: redis:6379`) and adds `depends_on: redis`.
- **Drive-by fix:** `LoggingPipelineBehaviorTests` failed to compile against the
  upgraded MediatR (`RequestHandlerDelegate<T>` now takes a `CancellationToken`).
  Fixed the test lambdas so the UnitTests project builds. Unrelated to the backplane,
  but it was blocking all unit tests from running.

## Testing

- **Unit tests:** 131/131 pass, including 3 new tests that assert the effective
  `HubLifetimeManager<>` registration — `Default…` when no connection string,
  `Redis…` when one is set (verified via service-descriptor inspection, no live Redis).
- **Ran the full stack in Docker** (`docker compose up --build`):
  - API logs `SignalR Redis backplane enabled.` and reports healthy.
  - Verified in Redis that the backplane established its pub/sub channels, all under
    the `awd:signalr` prefix (e.g. `awd:signalr…UserNotificationHub:all`).
  - AgentService negotiated and connected to the hub through the backplane (`negotiate` → 200).

## Deployment notes / out of scope

- **Sticky sessions required at scale.** The backplane fans out *messages* but does
  not route the SignalR connection handshake. A multi-instance deployment must enable
  session affinity at the load balancer (or pin clients to WebSockets + skip negotiation).
- **Data Protection** keys default to per-instance storage; point the key ring at
  Redis/blob for multi-instance (low impact here — auth is stateless JWT).
- No Redis resilience/retry policy and no durable notification queue — consistent with
  the deliberate "resilience is a later phase" stance for the realtime subsystem.

