### PR TITLE
Fix comment fetching for new API response

### DIFF
--- a/src/AreWeDoomd.ActivityNotifications.Contracts/AreWeDoomd.ActivityNotifications.Contracts.csproj
+++ b/src/AreWeDoomd.ActivityNotifications.Contracts/AreWeDoomd.ActivityNotifications.Contracts.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
   </ItemGroup>
 

--- a/src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj
+++ b/src/AreWeDoomd.AgentService/AreWeDoomd.AgentService.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />

--- a/src/AreWeDoomd.AgentService/Context/ContextFetcher.cs
+++ b/src/AreWeDoomd.AgentService/Context/ContextFetcher.cs
@@ -40,8 +40,9 @@ public sealed class ContextFetcher : IContextFetcher
                 return null;
             }
 
-            var comments = await GetAsync<List<ApiCommentResponse>>(
-                client, $"{baseUrl}/api/posts/{postId}/comments", agentUserId, ct) ?? [];
+            var commentList = await GetAsync<ApiCommentListResponse>(
+                client, $"{baseUrl}/api/posts/{postId}/comments", agentUserId, ct);
+            var comments = commentList?.Comments ?? [];
 
             return new PostThreadContext(
                 new PostInfo(post.Id, post.Author.Username, post.Author.UserType, post.Content),

--- a/src/AreWeDoomd.AgentService/Context/Wire/ApiCommentListResponse.cs
+++ b/src/AreWeDoomd.AgentService/Context/Wire/ApiCommentListResponse.cs
@@ -1,0 +1,7 @@
+namespace AreWeDoomd.AgentService.Context.Wire;
+
+internal sealed record ApiCommentListResponse(
+    List<ApiCommentResponse> Comments,
+    int TotalCount,
+    bool HasMoreBefore,
+    bool HasMoreAfter);

--- a/src/AreWeDoomd.Api/AreWeDoomd.Api.csproj
+++ b/src/AreWeDoomd.Api/AreWeDoomd.Api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.9" />

--- a/src/AreWeDoomd.Application/AreWeDoomd.Application.csproj
+++ b/src/AreWeDoomd.Application/AreWeDoomd.Application.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>

--- a/src/AreWeDoomd.Domain/AreWeDoomd.Domain.csproj
+++ b/src/AreWeDoomd.Domain/AreWeDoomd.Domain.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
   </ItemGroup>
 

--- a/src/AreWeDoomd.Infrastructure/AreWeDoomd.Infrastructure.csproj
+++ b/src/AreWeDoomd.Infrastructure/AreWeDoomd.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />

--- a/tests/AreWeDoomd.IntegrationTests/AgentService/ContextFetcherApiContractTests.cs
+++ b/tests/AreWeDoomd.IntegrationTests/AgentService/ContextFetcherApiContractTests.cs
@@ -1,0 +1,82 @@
+using AreWeDoomd.AgentService;
+using AreWeDoomd.AgentService.Context;
+using AreWeDoomd.Application.Features.Comments.Common;
+using AreWeDoomd.Application.Features.Common;
+using AreWeDoomd.Application.Features.Posts.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.IntegrationTests.AgentService;
+
+/// <summary>
+/// End-to-end contract test for <see cref="ContextFetcher"/> against the real API.
+/// Unlike the unit test (which hand-writes the response JSON and therefore can only ever
+/// agree with the wire DTO it was written next to), this test lets the real API serialize
+/// the response. If the API's comment-list response shape drifts away from what
+/// <see cref="ContextFetcher"/> expects, this test goes red.
+/// </summary>
+public sealed class ContextFetcherApiContractTests : IClassFixture<StubbedApiFactory>
+{
+    private readonly StubbedApiFactory _factory;
+
+    public ContextFetcherApiContractTests(StubbedApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task FetchAsync_ParsesCommentsFromRealApiResponse()
+    {
+        var postId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var commentId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        var postAuthor = new PostAuthorResult(
+            Guid.Parse("22222222-2222-2222-2222-222222222222"), "doombot", "Ai", null);
+        var commentAuthor = new PostAuthorResult(
+            Guid.Parse("44444444-4444-4444-4444-444444444444"), "alice", "Human", null);
+
+        _factory.PostResult = new PostResult(
+            postId, postAuthor, "Is AGI near?", LikeCount: 0, CommentCount: 1,
+            CreatedAt: new DateTimeOffset(2026, 6, 10, 10, 0, 0, TimeSpan.Zero), UpdatedAt: null);
+        _factory.CommentListResult = new CommentListResult(
+            Comments:
+            [
+                new CommentResult(
+                    commentId, postId, commentAuthor, "Probably not.", LikeCount: 0,
+                    CreatedAt: new DateTimeOffset(2026, 6, 10, 10, 5, 0, TimeSpan.Zero), UpdatedAt: null)
+            ],
+            TotalCount: 1,
+            HasMoreBefore: false,
+            HasMoreAfter: false);
+
+        var fetcher = CreateFetcher();
+
+        var context = await fetcher.FetchAsync(postId, postAuthor.UserId.ToString(), CancellationToken.None);
+
+        context.ShouldNotBeNull();
+        context!.Post.AuthorUsername.ShouldBe("doombot");
+        context.Post.AuthorUserType.ShouldBe("Ai");
+        context.Post.Content.ShouldBe("Is AGI near?");
+        context.Comments.Count.ShouldBe(1);
+        context.Comments[0].AuthorUsername.ShouldBe("alice");
+        context.Comments[0].AuthorUserType.ShouldBe("Human");
+        context.Comments[0].Content.ShouldBe("Probably not.");
+    }
+
+    private ContextFetcher CreateFetcher()
+    {
+        var httpClientFactory = new SingleClientHttpFactory(_factory.CreateClient());
+        var options = Options.Create(new AgentServiceOptions { ApiBaseUrl = "http://localhost" });
+
+        return new ContextFetcher(httpClientFactory, options, NullLogger<ContextFetcher>.Instance);
+    }
+
+    private sealed class SingleClientHttpFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+        {
+            return client;
+        }
+    }
+}

--- a/tests/AreWeDoomd.IntegrationTests/AgentService/StubbedApiFactory.cs
+++ b/tests/AreWeDoomd.IntegrationTests/AgentService/StubbedApiFactory.cs
@@ -1,0 +1,78 @@
+using AreWeDoomd.Application.Common.Results;
+using AreWeDoomd.Application.Features.Comments.Common;
+using AreWeDoomd.Application.Features.Comments.Queries.GetPostComments;
+using AreWeDoomd.Application.Features.Posts.Common;
+using AreWeDoomd.Application.Features.Posts.Queries.GetPost;
+using MediatR;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace AreWeDoomd.IntegrationTests.AgentService;
+
+/// <summary>
+/// Spins up the real API in-memory but replaces the MediatR query handlers behind the
+/// posts/comments endpoints with stubs, so the test exercises the real controllers and
+/// the real JSON serializer without needing a database. The whole point is that the
+/// response JSON is produced by the API itself — not hand-written in the test — so a
+/// change to the API's response shape is caught by anything that deserializes it.
+/// </summary>
+public sealed class StubbedApiFactory : WebApplicationFactory<Program>
+{
+    public PostResult? PostResult { get; set; }
+
+    public CommentListResult? CommentListResult { get; set; }
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.UseSerilog((_, loggerConfig) =>
+            loggerConfig.WriteTo.Console());
+
+        return base.CreateHost(builder);
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // A dummy connection string keeps startup happy; no test path actually hits the DB.
+        builder.UseSetting(
+            "ConnectionStrings:AreWeDoomdSql",
+            "Server=localhost;Database=test;Trusted_Connection=True;TrustServerCertificate=True;");
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<IRequestHandler<GetPostQuery, Result<PostResult>>>();
+            services.AddTransient<IRequestHandler<GetPostQuery, Result<PostResult>>>(
+                _ => new StubGetPostHandler(this));
+
+            services.RemoveAll<IRequestHandler<GetPostCommentsQuery, Result<CommentListResult>>>();
+            services.AddTransient<IRequestHandler<GetPostCommentsQuery, Result<CommentListResult>>>(
+                _ => new StubGetPostCommentsHandler(this));
+        });
+    }
+
+    private sealed class StubGetPostHandler(StubbedApiFactory factory)
+        : IRequestHandler<GetPostQuery, Result<PostResult>>
+    {
+        public Task<Result<PostResult>> Handle(GetPostQuery request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(factory.PostResult is { } post
+                ? Result<PostResult>.Success(post)
+                : Result<PostResult>.NotFound("post.not_found", "Post not found."));
+        }
+    }
+
+    private sealed class StubGetPostCommentsHandler(StubbedApiFactory factory)
+        : IRequestHandler<GetPostCommentsQuery, Result<CommentListResult>>
+    {
+        public Task<Result<CommentListResult>> Handle(GetPostCommentsQuery request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(factory.CommentListResult is { } list
+                ? Result<CommentListResult>.Success(list)
+                : Result<CommentListResult>.Success(new CommentListResult([], 0, false, false)));
+        }
+    }
+}

--- a/tests/AreWeDoomd.IntegrationTests/AreWeDoomd.IntegrationTests.csproj
+++ b/tests/AreWeDoomd.IntegrationTests/AreWeDoomd.IntegrationTests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AreWeDoomd.Api\AreWeDoomd.Api.csproj" />
+    <ProjectReference Include="..\..\src\AreWeDoomd.AgentService\AreWeDoomd.AgentService.csproj" />
     <ProjectReference Include="..\..\src\AreWeDoomd.Application\AreWeDoomd.Application.csproj" />
     <ProjectReference Include="..\..\src\AreWeDoomd.ActivityNotifications.Contracts\AreWeDoomd.ActivityNotifications.Contracts.csproj" />
   </ItemGroup>

--- a/tests/AreWeDoomd.IntegrationTests/AssemblyInfo.cs
+++ b/tests/AreWeDoomd.IntegrationTests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using Xunit;
+
+// These integration tests each spin up the real API via WebApplicationFactory<Program>.
+// Running multiple such factories in parallel races on the shared top-level-statement
+// entry point and intermittently throws "entry point exited without ever building an
+// IHost". Serializing the assembly's tests removes that race.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/AreWeDoomd.UnitTests/AgentService/Context/ContextFetcherTests.cs
+++ b/tests/AreWeDoomd.UnitTests/AgentService/Context/ContextFetcherTests.cs
@@ -21,7 +21,7 @@ public sealed class ContextFetcherTests
         {"id":"{{PostId}}","author":{"userId":"22222222-2222-2222-2222-222222222222","username":"doombot","userType":"Ai","profileImageUrl":null},"content":"Is AGI near?","likeCount":0,"commentCount":1,"createdAt":"2026-06-10T10:00:00Z","updatedAt":null}
         """;
         var commentsJson = """
-        [{"id":"33333333-3333-3333-3333-333333333333","postId":"11111111-1111-1111-1111-111111111111","author":{"userId":"44444444-4444-4444-4444-444444444444","username":"alice","userType":"Human","profileImageUrl":null},"content":"Probably not.","likeCount":0,"createdAt":"2026-06-10T10:05:00Z","updatedAt":null}]
+        {"comments":[{"id":"33333333-3333-3333-3333-333333333333","postId":"11111111-1111-1111-1111-111111111111","author":{"userId":"44444444-4444-4444-4444-444444444444","username":"alice","userType":"Human","profileImageUrl":null},"content":"Probably not.","likeCount":0,"createdAt":"2026-06-10T10:05:00Z","updatedAt":null}],"totalCount":1,"hasMoreBefore":false,"hasMoreAfter":false}
         """;
         var fetcher = CreateFetcher(request =>
         {

--- a/tests/AreWeDoomd.UnitTests/AreWeDoomd.UnitTests.csproj
+++ b/tests/AreWeDoomd.UnitTests/AreWeDoomd.UnitTests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
Updated `ContextFetcher` to handle `ApiCommentListResponse` structure. Adjusted `ContextFetcherTests` to use the updated response format. Added `ApiCommentListResponse` record to represent the new API response, including pagination details.