### PR TITLE
Add comment-like count to posts and ranked global feed

### DIFF
--- a/src/AreWeDoomd.Api/Contracts/Feed/GlobalFeedResponse.cs
+++ b/src/AreWeDoomd.Api/Contracts/Feed/GlobalFeedResponse.cs
@@ -1,0 +1,6 @@
+namespace AreWeDoomd.Api.Contracts.Feed;
+
+public sealed record GlobalFeedResponse(
+    IReadOnlyList<FeedPostResponse> Items,
+    DateTimeOffset AsOf,
+    bool HasMore);

--- a/src/AreWeDoomd.Api/Controllers/FeedController.cs
+++ b/src/AreWeDoomd.Api/Controllers/FeedController.cs
@@ -36,14 +36,18 @@ public sealed class FeedController(IMediator mediator) : ControllerBase
     }
 
     [HttpGet("global")]
-    [ProducesResponseType(typeof(IReadOnlyList<FeedPostResponse>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IReadOnlyList<FeedPostResponse>>> GetGlobalFeed(
-        CancellationToken cancellationToken)
+    [ProducesResponseType(typeof(GlobalFeedResponse), StatusCodes.Status200OK)]
+    public async Task<ActionResult<GlobalFeedResponse>> GetGlobalFeed(
+        [FromQuery] DateTimeOffset? asOf,
+        [FromQuery] int offset = 0,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
     {
         var includeAllComments = User.Identity?.IsAuthenticated == true;
-        var result = await mediator.Send(new GetGlobalFeedQuery(includeAllComments), cancellationToken);
+        var result = await mediator.Send(
+            new GetGlobalFeedQuery(includeAllComments, asOf, offset, pageSize), cancellationToken);
 
-        return this.ToActionResult(result, MapPosts);
+        return this.ToActionResult(result, MapGlobalFeed);
     }
 
     private bool TryGetCurrentUserId(out Guid userId)
@@ -51,6 +55,11 @@ public sealed class FeedController(IMediator mediator) : ControllerBase
         userId = Guid.Empty;
         var claim = User.FindFirstValue(ClaimTypes.NameIdentifier);
         return !string.IsNullOrWhiteSpace(claim) && Guid.TryParse(claim, out userId);
+    }
+
+    private static GlobalFeedResponse MapGlobalFeed(GlobalFeedResult result)
+    {
+        return new GlobalFeedResponse(MapPosts(result.Posts), result.AsOf, result.HasMore);
     }
 
     private static IReadOnlyList<FeedPostResponse> MapPosts(IReadOnlyList<FeedPostResult> results)

--- a/src/AreWeDoomd.Application/Common/Interfaces/IFeedRepository.cs
+++ b/src/AreWeDoomd.Application/Common/Interfaces/IFeedRepository.cs
@@ -5,5 +5,15 @@ namespace AreWeDoomd.Application.Common.Interfaces;
 public interface IFeedRepository
 {
     Task<IReadOnlyList<FeedPostResult>> GetFollowingFeedAsync(Guid userId, CancellationToken cancellationToken);
-    Task<IReadOnlyList<FeedPostResult>> GetGlobalFeedAsync(bool includeAllComments, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<FeedPostResult>> GetGlobalCandidatesAsync(
+        DateTimeOffset asOf,
+        DateTimeOffset? createdAfter,
+        int maxCandidates,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<FeedPostResult>> AttachCommentsAsync(
+        IReadOnlyList<FeedPostResult> posts,
+        bool includeAllComments,
+        CancellationToken cancellationToken);
 }

--- a/src/AreWeDoomd.Application/Features/CommentLikes/Commands/LikeComment/LikeCommentCommandHandler.cs
+++ b/src/AreWeDoomd.Application/Features/CommentLikes/Commands/LikeComment/LikeCommentCommandHandler.cs
@@ -37,6 +37,8 @@ public sealed class LikeCommentCommandHandler(
             return Result<bool>.Conflict("comment_like.already_liked", "You have already liked this comment.");
         }
 
+        post.IncrementCommentLikeCount();
+
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
         return Result<bool>.Success(true);

--- a/src/AreWeDoomd.Application/Features/CommentLikes/Commands/UnlikeComment/UnlikeCommentCommandHandler.cs
+++ b/src/AreWeDoomd.Application/Features/CommentLikes/Commands/UnlikeComment/UnlikeCommentCommandHandler.cs
@@ -36,6 +36,8 @@ public sealed class UnlikeCommentCommandHandler(
             return Result<bool>.NotFound("comment_like.not_found", "You have not liked this comment.");
         }
 
+        post.DecrementCommentLikeCount();
+
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
         return Result<bool>.Success(true);

--- a/src/AreWeDoomd.Application/Features/Feed/Common/FeedPostResult.cs
+++ b/src/AreWeDoomd.Application/Features/Feed/Common/FeedPostResult.cs
@@ -9,6 +9,7 @@ public sealed record FeedPostResult(
     string Content,
     int LikeCount,
     int CommentCount,
+    int CommentLikeCount,
     IReadOnlyList<CommentResult> Comments,
     DateTimeOffset CreatedAt,
     DateTimeOffset? UpdatedAt);

--- a/src/AreWeDoomd.Application/Features/Feed/Common/GlobalFeedResult.cs
+++ b/src/AreWeDoomd.Application/Features/Feed/Common/GlobalFeedResult.cs
@@ -1,0 +1,6 @@
+namespace AreWeDoomd.Application.Features.Feed.Common;
+
+public sealed record GlobalFeedResult(
+    IReadOnlyList<FeedPostResult> Posts,
+    DateTimeOffset AsOf,
+    bool HasMore);

--- a/src/AreWeDoomd.Application/Features/Feed/Queries/GetGlobalFeed/GetGlobalFeedQuery.cs
+++ b/src/AreWeDoomd.Application/Features/Feed/Queries/GetGlobalFeed/GetGlobalFeedQuery.cs
@@ -4,4 +4,8 @@ using MediatR;
 
 namespace AreWeDoomd.Application.Features.Feed.Queries.GetGlobalFeed;
 
-public sealed record GetGlobalFeedQuery(bool IncludeAllComments) : IRequest<Result<IReadOnlyList<FeedPostResult>>>;
+public sealed record GetGlobalFeedQuery(
+    bool IncludeAllComments,
+    DateTimeOffset? AsOf,
+    int Offset,
+    int PageSize) : IRequest<Result<GlobalFeedResult>>;

--- a/src/AreWeDoomd.Application/Features/Feed/Queries/GetGlobalFeed/GetGlobalFeedQueryHandler.cs
+++ b/src/AreWeDoomd.Application/Features/Feed/Queries/GetGlobalFeed/GetGlobalFeedQueryHandler.cs
@@ -1,18 +1,51 @@
 using AreWeDoomd.Application.Common.Interfaces;
 using AreWeDoomd.Application.Common.Results;
 using AreWeDoomd.Application.Features.Feed.Common;
+using AreWeDoomd.Application.Features.Feed.Ranking;
 using MediatR;
 
 namespace AreWeDoomd.Application.Features.Feed.Queries.GetGlobalFeed;
 
-public sealed class GetGlobalFeedQueryHandler(IFeedRepository feedRepository)
-    : IRequestHandler<GetGlobalFeedQuery, Result<IReadOnlyList<FeedPostResult>>>
+public sealed class GetGlobalFeedQueryHandler(
+    IFeedRepository feedRepository,
+    IDateTimeProvider dateTimeProvider)
+    : IRequestHandler<GetGlobalFeedQuery, Result<GlobalFeedResult>>
 {
-    public async Task<Result<IReadOnlyList<FeedPostResult>>> Handle(
+    private const int WindowDays = 30;
+    private const int FallbackThreshold = 20;
+    private const int MaxCandidates = 1000;
+    private const int MaxPageSize = 50;
+
+    public async Task<Result<GlobalFeedResult>> Handle(
         GetGlobalFeedQuery request, CancellationToken cancellationToken)
     {
-        var posts = await feedRepository.GetGlobalFeedAsync(request.IncludeAllComments, cancellationToken);
+        var asOf = request.AsOf ?? dateTimeProvider.UtcNow;
+        var offset = Math.Max(0, request.Offset);
+        var pageSize = Math.Clamp(request.PageSize, 1, MaxPageSize);
 
-        return Result<IReadOnlyList<FeedPostResult>>.Success(posts);
+        // Candidates are the most-recent posts within the window, capped at MaxCandidates.
+        // The cap is biased toward recency on purpose: with time-decay ranking, older posts
+        // score near the bottom anyway, so excluding the oldest of a very large window does
+        // not affect the top of the feed. The fallback (createdAfter: null) is a superset of
+        // the windowed set under the same recency ordering, so replacing is safe.
+        var candidates = await feedRepository.GetGlobalCandidatesAsync(
+            asOf, asOf.AddDays(-WindowDays), MaxCandidates, cancellationToken);
+
+        if (candidates.Count < FallbackThreshold)
+        {
+            candidates = await feedRepository.GetGlobalCandidatesAsync(
+                asOf, null, MaxCandidates, cancellationToken);
+        }
+
+        var ranked = FeedScorer.Rank(candidates, asOf);
+
+        var pageSlice = ranked.Skip(offset).Take(pageSize).ToList();
+        var hasMore = ranked.Count > offset + pageSize;
+
+        var withComments = await feedRepository.AttachCommentsAsync(
+            pageSlice, request.IncludeAllComments, cancellationToken);
+
+        return Result<GlobalFeedResult>.Success(
+            new GlobalFeedResult(withComments, asOf, hasMore));
     }
 }

--- a/src/AreWeDoomd.Application/Features/Feed/Ranking/FeedScorer.cs
+++ b/src/AreWeDoomd.Application/Features/Feed/Ranking/FeedScorer.cs
@@ -1,0 +1,36 @@
+using AreWeDoomd.Application.Features.Feed.Common;
+
+namespace AreWeDoomd.Application.Features.Feed.Ranking;
+
+public static class FeedScorer
+{
+    private const double CommentWeight = 3.0;
+    private const double LikeWeight = 1.0;
+    private const double CommentLikeWeight = 0.5;
+    private const double Gravity = 1.5;
+    private const double BaseScore = 1.0;
+    private const double AgeOffsetHours = 2.0;
+
+    public static IReadOnlyList<FeedPostResult> Rank(
+        IReadOnlyList<FeedPostResult> posts,
+        DateTimeOffset now)
+    {
+        return posts
+            .OrderByDescending(post => Score(post, now))
+            .ThenByDescending(post => post.CreatedAt)
+            .ThenBy(post => post.Id)
+            .ToList();
+    }
+
+    private static double Score(FeedPostResult post, DateTimeOffset now)
+    {
+        var ageHours = Math.Max(0.0, (now - post.CreatedAt).TotalHours);
+
+        var engagement = BaseScore
+            + (CommentWeight * post.CommentCount)
+            + (LikeWeight * post.LikeCount)
+            + (CommentLikeWeight * post.CommentLikeCount);
+
+        return engagement / Math.Pow(ageHours + AgeOffsetHours, Gravity);
+    }
+}

--- a/src/AreWeDoomd.Domain/Posts/Post.cs
+++ b/src/AreWeDoomd.Domain/Posts/Post.cs
@@ -11,6 +11,7 @@ namespace AreWeDoomd.Domain.Posts
         // Denormalized counters (transaction/concurrency ile güncellenmeli)
         public int LikeCount { get; private set; }
         public int CommentCount { get; private set; }
+        public int CommentLikeCount { get; private set; }
 
         // EF Core backing fields
         private readonly List<PostLike> _likes = [];
@@ -118,7 +119,18 @@ namespace AreWeDoomd.Domain.Posts
 
             _comments.Remove(comment);
             CommentCount = Math.Max(0, CommentCount - 1);
+            CommentLikeCount = Math.Max(0, CommentLikeCount - comment.LikeCount);
             return true;
+        }
+
+        public void IncrementCommentLikeCount()
+        {
+            CommentLikeCount++;
+        }
+
+        public void DecrementCommentLikeCount()
+        {
+            CommentLikeCount = Math.Max(0, CommentLikeCount - 1);
         }
 
         private void SetContent(string content)

--- a/src/AreWeDoomd.Infrastructure/Common/Repositories/FeedRepository.cs
+++ b/src/AreWeDoomd.Infrastructure/Common/Repositories/FeedRepository.cs
@@ -32,6 +32,7 @@ public sealed class FeedRepository(AreWeDoomdDbContext dbContext) : IFeedReposit
                     p.Content,
                     p.LikeCount,
                     p.CommentCount,
+                    p.CommentLikeCount,
                     Array.Empty<CommentResult>(),
                     p.CreatedAt,
                     p.UpdatedAt))
@@ -40,12 +41,22 @@ public sealed class FeedRepository(AreWeDoomdDbContext dbContext) : IFeedReposit
         return await AttachCommentsAsync(posts, FeedCommentsPerPost, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<FeedPostResult>> GetGlobalFeedAsync(
-        bool includeAllComments,
+    public async Task<IReadOnlyList<FeedPostResult>> GetGlobalCandidatesAsync(
+        DateTimeOffset asOf,
+        DateTimeOffset? createdAfter,
+        int maxCandidates,
         CancellationToken cancellationToken)
     {
-        var posts = await dbContext.Posts
+        var query = dbContext.Posts.Where(p => p.CreatedAt <= asOf);
+
+        if (createdAfter is not null)
+        {
+            query = query.Where(p => p.CreatedAt >= createdAfter.Value);
+        }
+
+        return await query
             .OrderByDescending(p => p.CreatedAt)
+            .Take(maxCandidates)
             .AsNoTracking()
             .Join(dbContext.Users,
                 p => p.UserId,
@@ -56,15 +67,20 @@ public sealed class FeedRepository(AreWeDoomdDbContext dbContext) : IFeedReposit
                     p.Content,
                     p.LikeCount,
                     p.CommentCount,
+                    p.CommentLikeCount,
                     Array.Empty<CommentResult>(),
                     p.CreatedAt,
                     p.UpdatedAt))
             .ToListAsync(cancellationToken);
+    }
 
-        return await AttachCommentsAsync(
-            posts,
-            includeAllComments ? FeedCommentsPerPost : GuestCommentsPerPost,
-            cancellationToken);
+    public Task<IReadOnlyList<FeedPostResult>> AttachCommentsAsync(
+        IReadOnlyList<FeedPostResult> posts,
+        bool includeAllComments,
+        CancellationToken cancellationToken)
+    {
+        var maxCommentsPerPost = includeAllComments ? FeedCommentsPerPost : GuestCommentsPerPost;
+        return AttachCommentsAsync(posts, maxCommentsPerPost, cancellationToken);
     }
 
     private async Task<IReadOnlyList<FeedPostResult>> AttachCommentsAsync(

--- a/src/AreWeDoomd.Infrastructure/Migrations/20260620163848_AddPostCommentLikeCount.Designer.cs
+++ b/src/AreWeDoomd.Infrastructure/Migrations/20260620163848_AddPostCommentLikeCount.Designer.cs
@@ -4,6 +4,7 @@ using AreWeDoomd.Infrastructure.Common.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AreWeDoomd.Infrastructure.Migrations
 {
     [DbContext(typeof(AreWeDoomdDbContext))]
-    partial class AreWeDoomdDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620163848_AddPostCommentLikeCount")]
+    partial class AddPostCommentLikeCount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AreWeDoomd.Infrastructure/Migrations/20260620163848_AddPostCommentLikeCount.cs
+++ b/src/AreWeDoomd.Infrastructure/Migrations/20260620163848_AddPostCommentLikeCount.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AreWeDoomd.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPostCommentLikeCount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CommentLikeCount",
+                table: "Posts",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.Sql(@"
+                UPDATE p
+                SET p.CommentLikeCount = ISNULL(c.Total, 0)
+                FROM Posts p
+                LEFT JOIN (
+                    SELECT PostId, SUM(LikeCount) AS Total
+                    FROM Comments
+                    GROUP BY PostId
+                ) c ON c.PostId = p.Id;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CommentLikeCount",
+                table: "Posts");
+        }
+    }
+}

--- a/tests/AreWeDoomd.UnitTests/Domain/Posts/PostCommentLikeCountTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Domain/Posts/PostCommentLikeCountTests.cs
@@ -1,0 +1,93 @@
+using AreWeDoomd.Domain.Posts;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Domain.Posts;
+
+public sealed class PostCommentLikeCountTests
+{
+    private static Post CreatePost()
+    {
+        return Post.Create(Guid.NewGuid(), "content", DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void IncrementCommentLikeCount_WhenCalled_ShouldIncreaseByOne()
+    {
+        var post = CreatePost();
+
+        post.IncrementCommentLikeCount();
+
+        post.CommentLikeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void DecrementCommentLikeCount_WhenPositive_ShouldDecreaseByOne()
+    {
+        var post = CreatePost();
+        post.IncrementCommentLikeCount();
+        post.IncrementCommentLikeCount();
+
+        post.DecrementCommentLikeCount();
+
+        post.CommentLikeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void DecrementCommentLikeCount_WhenZero_ShouldStayZero()
+    {
+        var post = CreatePost();
+
+        post.DecrementCommentLikeCount();
+
+        post.CommentLikeCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemoveComment_WhenCommentHadLikes_ShouldReduceCommentLikeCountByThatAmount()
+    {
+        var post = CreatePost();
+        var comment = post.AddComment(Guid.NewGuid(), "a comment", DateTimeOffset.UtcNow);
+        comment.Like(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        comment.Like(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        post.IncrementCommentLikeCount();
+        post.IncrementCommentLikeCount();
+
+        post.RemoveComment(comment.Id);
+
+        post.CommentLikeCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RemoveComment_WhenOtherCommentsRetainLikes_ShouldOnlySubtractRemovedCommentsLikes()
+    {
+        var post = CreatePost();
+        var kept = post.AddComment(Guid.NewGuid(), "kept", DateTimeOffset.UtcNow);
+        var removed = post.AddComment(Guid.NewGuid(), "removed", DateTimeOffset.UtcNow);
+        kept.Like(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        removed.Like(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        removed.Like(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        // Post rollup = 3 likes total (1 kept + 2 removed), as the handler would have incremented.
+        post.IncrementCommentLikeCount();
+        post.IncrementCommentLikeCount();
+        post.IncrementCommentLikeCount();
+
+        post.RemoveComment(removed.Id);
+
+        post.CommentLikeCount.ShouldBe(1);
+    }
+
+    [Fact]
+    public void RemoveComment_WhenCommentHadNoLikes_ShouldLeaveCommentLikeCountUnchanged()
+    {
+        var post = CreatePost();
+        var liked = post.AddComment(Guid.NewGuid(), "liked", DateTimeOffset.UtcNow);
+        var unliked = post.AddComment(Guid.NewGuid(), "unliked", DateTimeOffset.UtcNow);
+        liked.Like(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        post.IncrementCommentLikeCount();
+
+        post.RemoveComment(unliked.Id);
+
+        post.CommentLikeCount.ShouldBe(1);
+    }
+}

--- a/tests/AreWeDoomd.UnitTests/Features/CommentLikes/Commands/LikeComment/LikeCommentCommandHandlerTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Features/CommentLikes/Commands/LikeComment/LikeCommentCommandHandlerTests.cs
@@ -1,0 +1,75 @@
+using AreWeDoomd.Application.Common.Interfaces;
+using AreWeDoomd.Application.Features.CommentLikes.Commands.LikeComment;
+using AreWeDoomd.Domain.Comments;
+using AreWeDoomd.Domain.Posts;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Features.CommentLikes.Commands.LikeComment;
+
+public sealed class LikeCommentCommandHandlerTests
+{
+    private static readonly Guid CommentId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 6, 20, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IPostRepository> _postRepositoryMock = new();
+    private readonly Mock<ICommentRepository> _commentRepositoryMock = new();
+    private readonly Mock<IDateTimeProvider> _dateTimeProviderMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly LikeCommentCommandHandler _handler;
+
+    public LikeCommentCommandHandlerTests()
+    {
+        _dateTimeProviderMock.SetupGet(p => p.UtcNow).Returns(Now);
+        _handler = new LikeCommentCommandHandler(
+            _postRepositoryMock.Object,
+            _commentRepositoryMock.Object,
+            _dateTimeProviderMock.Object,
+            _unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCommentLiked_ShouldIncrementPostCommentLikeCount()
+    {
+        var post = Post.Create(Guid.NewGuid(), "content", Now);
+        var comment = Comment.Create(post.Id, Guid.NewGuid(), "a comment", Now);
+
+        _postRepositoryMock
+            .Setup(r => r.GetByIdAsync(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _commentRepositoryMock
+            .Setup(r => r.GetByIdWithLikesAsync(post.Id, CommentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(comment);
+
+        var result = await _handler.Handle(
+            new LikeCommentCommand(post.Id, CommentId, UserId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        post.CommentLikeCount.ShouldBe(1);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAlreadyLiked_ShouldNotIncrementPostCommentLikeCount()
+    {
+        var post = Post.Create(Guid.NewGuid(), "content", Now);
+        var comment = Comment.Create(post.Id, Guid.NewGuid(), "a comment", Now);
+        comment.Like(UserId, Now);
+
+        _postRepositoryMock
+            .Setup(r => r.GetByIdAsync(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _commentRepositoryMock
+            .Setup(r => r.GetByIdWithLikesAsync(post.Id, CommentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(comment);
+
+        var result = await _handler.Handle(
+            new LikeCommentCommand(post.Id, CommentId, UserId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        post.CommentLikeCount.ShouldBe(0);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/AreWeDoomd.UnitTests/Features/CommentLikes/Commands/UnlikeComment/UnlikeCommentCommandHandlerTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Features/CommentLikes/Commands/UnlikeComment/UnlikeCommentCommandHandlerTests.cs
@@ -1,0 +1,74 @@
+using AreWeDoomd.Application.Common.Interfaces;
+using AreWeDoomd.Application.Features.CommentLikes.Commands.UnlikeComment;
+using AreWeDoomd.Domain.Comments;
+using AreWeDoomd.Domain.Posts;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Features.CommentLikes.Commands.UnlikeComment;
+
+public sealed class UnlikeCommentCommandHandlerTests
+{
+    private static readonly Guid CommentId = Guid.NewGuid();
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly DateTimeOffset Now = new(2026, 6, 20, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IPostRepository> _postRepositoryMock = new();
+    private readonly Mock<ICommentRepository> _commentRepositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly UnlikeCommentCommandHandler _handler;
+
+    public UnlikeCommentCommandHandlerTests()
+    {
+        _handler = new UnlikeCommentCommandHandler(
+            _postRepositoryMock.Object,
+            _commentRepositoryMock.Object,
+            _unitOfWorkMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WhenCommentUnliked_ShouldDecrementPostCommentLikeCount()
+    {
+        var post = Post.Create(Guid.NewGuid(), "content", Now);
+        post.IncrementCommentLikeCount();
+        var comment = Comment.Create(post.Id, Guid.NewGuid(), "a comment", Now);
+        comment.Like(UserId, Now);
+
+        _postRepositoryMock
+            .Setup(r => r.GetByIdAsync(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _commentRepositoryMock
+            .Setup(r => r.GetByIdWithLikesAsync(post.Id, CommentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(comment);
+
+        var result = await _handler.Handle(
+            new UnlikeCommentCommand(post.Id, CommentId, UserId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        post.CommentLikeCount.ShouldBe(0);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNotPreviouslyLiked_ShouldNotDecrementPostCommentLikeCount()
+    {
+        var post = Post.Create(Guid.NewGuid(), "content", Now);
+        post.IncrementCommentLikeCount();
+        var comment = Comment.Create(post.Id, Guid.NewGuid(), "a comment", Now);
+
+        _postRepositoryMock
+            .Setup(r => r.GetByIdAsync(post.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(post);
+        _commentRepositoryMock
+            .Setup(r => r.GetByIdWithLikesAsync(post.Id, CommentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(comment);
+
+        var result = await _handler.Handle(
+            new UnlikeCommentCommand(post.Id, CommentId, UserId), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        post.CommentLikeCount.ShouldBe(1);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/tests/AreWeDoomd.UnitTests/Features/Feed/Queries/GetGlobalFeed/GetGlobalFeedQueryHandlerTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Features/Feed/Queries/GetGlobalFeed/GetGlobalFeedQueryHandlerTests.cs
@@ -1,0 +1,178 @@
+using AreWeDoomd.Application.Common.Interfaces;
+using AreWeDoomd.Application.Features.Comments.Common;
+using AreWeDoomd.Application.Features.Common;
+using AreWeDoomd.Application.Features.Feed.Common;
+using AreWeDoomd.Application.Features.Feed.Queries.GetGlobalFeed;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Features.Feed.Queries.GetGlobalFeed;
+
+public sealed class GetGlobalFeedQueryHandlerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 20, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly Mock<IFeedRepository> _feedRepositoryMock = new();
+    private readonly Mock<IDateTimeProvider> _dateTimeProviderMock = new();
+    private readonly GetGlobalFeedQueryHandler _handler;
+
+    public GetGlobalFeedQueryHandlerTests()
+    {
+        _dateTimeProviderMock.SetupGet(p => p.UtcNow).Returns(Now);
+
+        _feedRepositoryMock
+            .Setup(r => r.AttachCommentsAsync(
+                It.IsAny<IReadOnlyList<FeedPostResult>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<FeedPostResult> posts, bool _, CancellationToken _) => posts);
+
+        _handler = new GetGlobalFeedQueryHandler(
+            _feedRepositoryMock.Object,
+            _dateTimeProviderMock.Object);
+    }
+
+    private static FeedPostResult Post(int likeCount, Guid? id = null)
+    {
+        return new FeedPostResult(
+            id ?? Guid.NewGuid(),
+            new PostAuthorResult(Guid.NewGuid(), "user", "Human", null),
+            "content",
+            likeCount,
+            0,
+            0,
+            Array.Empty<CommentResult>(),
+            Now.AddHours(-1),
+            null);
+    }
+
+    private static List<FeedPostResult> Candidates(int count)
+    {
+        return Enumerable.Range(0, count).Select(i => Post(i)).ToList();
+    }
+
+    private void SetupWindowed(IReadOnlyList<FeedPostResult> result)
+    {
+        _feedRepositoryMock
+            .Setup(r => r.GetGlobalCandidatesAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.Is<DateTimeOffset?>(d => d.HasValue),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+    }
+
+    private void SetupFallback(IReadOnlyList<FeedPostResult> result)
+    {
+        _feedRepositoryMock
+            .Setup(r => r.GetGlobalCandidatesAsync(
+                It.IsAny<DateTimeOffset>(),
+                It.Is<DateTimeOffset?>(d => !d.HasValue),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAsOfNull_ShouldStampUtcNowAndReturnIt()
+    {
+        SetupWindowed(Candidates(25));
+
+        var result = await _handler.Handle(
+            new GetGlobalFeedQuery(true, null, 0, 20), CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Value!.AsOf.ShouldBe(Now);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAsOfProvided_ShouldUseItAsReferenceTime()
+    {
+        var asOf = Now.AddHours(-3);
+        SetupWindowed(Candidates(25));
+
+        var result = await _handler.Handle(
+            new GetGlobalFeedQuery(true, asOf, 0, 20), CancellationToken.None);
+
+        result.Value!.AsOf.ShouldBe(asOf);
+        _feedRepositoryMock.Verify(r => r.GetGlobalCandidatesAsync(
+            asOf, It.IsAny<DateTimeOffset?>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEnoughCandidates_ShouldNotFallBack()
+    {
+        SetupWindowed(Candidates(25));
+
+        await _handler.Handle(new GetGlobalFeedQuery(true, null, 0, 20), CancellationToken.None);
+
+        _feedRepositoryMock.Verify(r => r.GetGlobalCandidatesAsync(
+            It.IsAny<DateTimeOffset>(), It.Is<DateTimeOffset?>(d => !d.HasValue),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenTooFewCandidates_ShouldFallBackToNoWindow()
+    {
+        SetupWindowed(Candidates(5));
+        SetupFallback(Candidates(25));
+
+        var result = await _handler.Handle(
+            new GetGlobalFeedQuery(true, null, 0, 20), CancellationToken.None);
+
+        result.Value!.Posts.Count.ShouldBe(20);
+        _feedRepositoryMock.Verify(r => r.GetGlobalCandidatesAsync(
+            It.IsAny<DateTimeOffset>(), It.Is<DateTimeOffset?>(d => !d.HasValue),
+            It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldPageByOffsetAndPageSizeInRankedOrder()
+    {
+        SetupWindowed(Candidates(25));
+
+        var page = await _handler.Handle(
+            new GetGlobalFeedQuery(true, null, 0, 10), CancellationToken.None);
+
+        page.Value!.Posts.Count.ShouldBe(10);
+        page.Value.Posts[0].LikeCount.ShouldBe(24);
+        page.Value.Posts[9].LikeCount.ShouldBe(15);
+        page.Value.HasMore.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WhenLastPage_ShouldReportHasMoreFalse()
+    {
+        SetupWindowed(Candidates(25));
+
+        var page = await _handler.Handle(
+            new GetGlobalFeedQuery(true, null, 20, 10), CancellationToken.None);
+
+        page.Value!.Posts.Count.ShouldBe(5);
+        page.Value.HasMore.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldClampPageSizeAndOffset()
+    {
+        SetupWindowed(Candidates(25));
+
+        var page = await _handler.Handle(
+            new GetGlobalFeedQuery(true, null, -5, 999), CancellationToken.None);
+
+        page.Value!.Posts.Count.ShouldBe(25);
+        page.Value.HasMore.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldAttachCommentsOnlyToThePageSlice()
+    {
+        SetupWindowed(Candidates(25));
+
+        await _handler.Handle(new GetGlobalFeedQuery(true, null, 0, 10), CancellationToken.None);
+
+        _feedRepositoryMock.Verify(r => r.AttachCommentsAsync(
+            It.Is<IReadOnlyList<FeedPostResult>>(p => p.Count == 10),
+            true,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/AreWeDoomd.UnitTests/Features/Feed/Ranking/FeedScorerTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Features/Feed/Ranking/FeedScorerTests.cs
@@ -1,0 +1,104 @@
+using AreWeDoomd.Application.Features.Comments.Common;
+using AreWeDoomd.Application.Features.Common;
+using AreWeDoomd.Application.Features.Feed.Common;
+using AreWeDoomd.Application.Features.Feed.Ranking;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.Features.Feed.Ranking;
+
+public sealed class FeedScorerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 20, 12, 0, 0, TimeSpan.Zero);
+
+    private static FeedPostResult Post(
+        Guid id,
+        DateTimeOffset createdAt,
+        int likeCount = 0,
+        int commentCount = 0,
+        int commentLikeCount = 0)
+    {
+        return new FeedPostResult(
+            id,
+            new PostAuthorResult(Guid.NewGuid(), "user", "Human", null),
+            "content",
+            likeCount,
+            commentCount,
+            commentLikeCount,
+            Array.Empty<CommentResult>(),
+            createdAt,
+            null);
+    }
+
+    [Fact]
+    public void Rank_WhenSameAge_ShouldOrderByEngagementDescending()
+    {
+        var createdAt = Now.AddHours(-1);
+        var low = Post(Guid.NewGuid(), createdAt, likeCount: 1);
+        var high = Post(Guid.NewGuid(), createdAt, likeCount: 50);
+
+        var ranked = FeedScorer.Rank(new[] { low, high }, Now);
+
+        ranked[0].Id.ShouldBe(high.Id);
+        ranked[1].Id.ShouldBe(low.Id);
+    }
+
+    [Fact]
+    public void Rank_WhenZeroEngagement_ShouldOrderByNewestFirst()
+    {
+        var older = Post(Guid.NewGuid(), Now.AddHours(-10));
+        var newer = Post(Guid.NewGuid(), Now.AddHours(-1));
+
+        var ranked = FeedScorer.Rank(new[] { older, newer }, Now);
+
+        ranked[0].Id.ShouldBe(newer.Id);
+        ranked[1].Id.ShouldBe(older.Id);
+    }
+
+    [Fact]
+    public void Rank_WhenOldPostHighlyEngaged_ShouldDecayBelowFreshLowEngagement()
+    {
+        var oldViral = Post(Guid.NewGuid(), Now.AddDays(-7), likeCount: 100);
+        var freshActive = Post(Guid.NewGuid(), Now.AddHours(-1), commentCount: 5);
+
+        var ranked = FeedScorer.Rank(new[] { oldViral, freshActive }, Now);
+
+        ranked[0].Id.ShouldBe(freshActive.Id);
+    }
+
+    [Fact]
+    public void Rank_WhenComparingSignals_ShouldWeightCommentAboveLikeAboveCommentLike()
+    {
+        var createdAt = Now.AddHours(-1);
+        var byComment = Post(Guid.NewGuid(), createdAt, commentCount: 10);
+        var byLike = Post(Guid.NewGuid(), createdAt, likeCount: 10);
+        var byCommentLike = Post(Guid.NewGuid(), createdAt, commentLikeCount: 10);
+
+        var ranked = FeedScorer.Rank(new[] { byLike, byCommentLike, byComment }, Now);
+
+        ranked[0].Id.ShouldBe(byComment.Id);
+        ranked[1].Id.ShouldBe(byLike.Id);
+        ranked[2].Id.ShouldBe(byCommentLike.Id);
+    }
+
+    [Fact]
+    public void Rank_WhenScoreAndCreatedAtTie_ShouldBreakByIdAscending()
+    {
+        var createdAt = Now.AddHours(-1);
+        var a = Post(new Guid("00000000-0000-0000-0000-000000000001"), createdAt);
+        var b = Post(new Guid("00000000-0000-0000-0000-000000000002"), createdAt);
+
+        var ranked = FeedScorer.Rank(new[] { b, a }, Now);
+
+        ranked[0].Id.ShouldBe(a.Id);
+        ranked[1].Id.ShouldBe(b.Id);
+    }
+
+    [Fact]
+    public void Rank_WhenEmpty_ShouldReturnEmpty()
+    {
+        var ranked = FeedScorer.Rank(Array.Empty<FeedPostResult>(), Now);
+
+        ranked.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
Introduce CommentLikeCount to Post, update on comment like/unlike and removal. Refactor global feed for paging, time-based queries, and new engagement-based ranking. Update API contracts, repository, and query handlers. Add migration for CommentLikeCount and comprehensive unit tests for new logic.