### PR TITLE
Refactor: replace "thread" with "post" for comments

### DIFF
--- a/src/AreWeDoomd.ActivityNotifications.Contracts/ActivityTargetType.cs
+++ b/src/AreWeDoomd.ActivityNotifications.Contracts/ActivityTargetType.cs
@@ -3,6 +3,5 @@ namespace AreWeDoomd.ActivityNotifications.Contracts;
 public enum ActivityTargetType
 {
     Post = 0,
-    Thread = 1,
     Group = 2
 }

--- a/src/AreWeDoomd.ActivityNotifications.Contracts/NotificationReason.cs
+++ b/src/AreWeDoomd.ActivityNotifications.Contracts/NotificationReason.cs
@@ -5,5 +5,5 @@ public enum NotificationReason
     PostOwner = 0,
     Mentioned = 1,
     Subscriber = 2,
-    ThreadParticipant = 3
+    PostParticipant = 3
 }

--- a/src/AreWeDoomd.AgentService/AgentServiceOptions.cs
+++ b/src/AreWeDoomd.AgentService/AgentServiceOptions.cs
@@ -17,12 +17,12 @@ public sealed class AgentServiceOptions
     /// <summary>Model id passed to the provider. Empty = provider default.</summary>
     public string Model { get; set; } = string.Empty;
 
-    /// <summary>AI↔AI thread depth at which effective priority drops to Low.</summary>
+    /// <summary>AI↔AI reply-chain depth at which effective priority drops to Low.</summary>
     public int DecayLowDepth { get; set; } = 2;
 
-    /// <summary>AI↔AI thread depth at which the closing instruction is used.</summary>
+    /// <summary>AI↔AI reply-chain depth at which the closing instruction is used.</summary>
     public int DecayClosingDepth { get; set; } = 3;
 
-    /// <summary>AI↔AI thread depth at which the LLM is no longer called.</summary>
+    /// <summary>AI↔AI reply-chain depth at which the LLM is no longer called.</summary>
     public int DecaySkipDepth { get; set; } = 4;
 }

--- a/src/AreWeDoomd.AgentService/Context/CommentInfo.cs
+++ b/src/AreWeDoomd.AgentService/Context/CommentInfo.cs
@@ -1,6 +1,6 @@
 namespace AreWeDoomd.AgentService.Context;
 
-public sealed record ThreadComment(
+public sealed record CommentInfo(
     Guid Id,
     string AuthorUsername,
     string AuthorUserType,

--- a/src/AreWeDoomd.AgentService/Context/ContextFetcher.cs
+++ b/src/AreWeDoomd.AgentService/Context/ContextFetcher.cs
@@ -26,7 +26,7 @@ public sealed class ContextFetcher : IContextFetcher
         _logger = logger;
     }
 
-    public async Task<PostThreadContext?> FetchAsync(Guid postId, string agentUserId, CancellationToken ct)
+    public async Task<PostContext?> FetchAsync(Guid postId, string agentUserId, CancellationToken ct)
     {
         HttpClient client = _httpClientFactory.CreateClient(HttpClientName);
         string baseUrl = _options.ApiBaseUrl.TrimEnd('/');
@@ -44,10 +44,10 @@ public sealed class ContextFetcher : IContextFetcher
                 client, $"{baseUrl}/api/posts/{postId}/comments", agentUserId, ct);
             var comments = commentList?.Comments ?? [];
 
-            return new PostThreadContext(
+            return new PostContext(
                 new PostInfo(post.Id, post.Author.Username, post.Author.UserType, post.Content),
                 comments
-                    .Select(c => new ThreadComment(
+                    .Select(c => new CommentInfo(
                         c.Id, c.Author.Username, c.Author.UserType, c.Content, c.CreatedAt))
                     .ToList());
         }

--- a/src/AreWeDoomd.AgentService/Context/IContextFetcher.cs
+++ b/src/AreWeDoomd.AgentService/Context/IContextFetcher.cs
@@ -2,5 +2,5 @@ namespace AreWeDoomd.AgentService.Context;
 
 public interface IContextFetcher
 {
-    Task<PostThreadContext?> FetchAsync(Guid postId, string agentUserId, CancellationToken ct);
+    Task<PostContext?> FetchAsync(Guid postId, string agentUserId, CancellationToken ct);
 }

--- a/src/AreWeDoomd.AgentService/Context/PostContext.cs
+++ b/src/AreWeDoomd.AgentService/Context/PostContext.cs
@@ -1,0 +1,5 @@
+namespace AreWeDoomd.AgentService.Context;
+
+public sealed record PostContext(
+    PostInfo Post,
+    IReadOnlyList<CommentInfo> Comments);

--- a/src/AreWeDoomd.AgentService/Context/PostThreadContext.cs
+++ b/src/AreWeDoomd.AgentService/Context/PostThreadContext.cs
@@ -1,5 +1,0 @@
-namespace AreWeDoomd.AgentService.Context;
-
-public sealed record PostThreadContext(
-    PostInfo Post,
-    IReadOnlyList<ThreadComment> Comments);

--- a/src/AreWeDoomd.AgentService/Processing/AgentEventProcessor.cs
+++ b/src/AreWeDoomd.AgentService/Processing/AgentEventProcessor.cs
@@ -133,7 +133,7 @@ public sealed class AgentEventProcessor : BackgroundService
         var input = new CommentCreatedPromptInput(
             ActorName: agentEvent.Actor.DisplayName,
             PostContent: context.Post.Content,
-            CommentThread: CommentThreadFormatter.Format(context.Comments),
+            Comments: CommentListFormatter.Format(context.Comments),
             IncomingComment: incomingComment,
             Priority: priority);
 

--- a/src/AreWeDoomd.AgentService/Processing/PriorityDecayPolicy.cs
+++ b/src/AreWeDoomd.AgentService/Processing/PriorityDecayPolicy.cs
@@ -16,7 +16,7 @@ public sealed class PriorityDecayPolicy
     public EffectivePriority Evaluate(
         ActorType actorType,
         NotificationPriority notificationPriority,
-        IReadOnlyList<ThreadComment> comments)
+        IReadOnlyList<CommentInfo> comments)
     {
         if (actorType != ActorType.Ai)
         {

--- a/src/AreWeDoomd.AgentService/Prompting/CommentCreatedPromptInput.cs
+++ b/src/AreWeDoomd.AgentService/Prompting/CommentCreatedPromptInput.cs
@@ -5,6 +5,6 @@ namespace AreWeDoomd.AgentService.Prompting;
 public sealed record CommentCreatedPromptInput(
     string ActorName,
     string PostContent,
-    string CommentThread,
+    string Comments,
     string IncomingComment,
     EffectivePriority Priority);

--- a/src/AreWeDoomd.AgentService/Prompting/CommentListFormatter.cs
+++ b/src/AreWeDoomd.AgentService/Prompting/CommentListFormatter.cs
@@ -2,9 +2,9 @@ using AreWeDoomd.AgentService.Context;
 
 namespace AreWeDoomd.AgentService.Prompting;
 
-public static class CommentThreadFormatter
+public static class CommentListFormatter
 {
-    public static string Format(IReadOnlyList<ThreadComment> comments)
+    public static string Format(IReadOnlyList<CommentInfo> comments)
     {
         if (comments.Count == 0)
         {

--- a/src/AreWeDoomd.AgentService/Prompting/PromptComposer.cs
+++ b/src/AreWeDoomd.AgentService/Prompting/PromptComposer.cs
@@ -18,7 +18,7 @@ public sealed class PromptComposer : IPromptComposer
         string task = _files.CommentCreatedTask
             .Replace("{{actor_name}}", input.ActorName)
             .Replace("{{post_content}}", input.PostContent)
-            .Replace("{{comment_thread}}", input.CommentThread)
+            .Replace("{{comments}}", input.Comments)
             .Replace("{{incoming_comment}}", input.IncomingComment)
             .Replace("{{priority_instruction}}", _files.PriorityInstruction(input.Priority));
 

--- a/src/AreWeDoomd.AgentService/Prompts/20-tasks/comment-created.md
+++ b/src/AreWeDoomd.AgentService/Prompts/20-tasks/comment-created.md
@@ -8,10 +8,10 @@ Your post:
 {{post_content}}
 ```
 
-The comment thread on your post so far (oldest first):
+The comments on your post so far (oldest first):
 
 ```user-content
-{{comment_thread}}
+{{comments}}
 ```
 
 The new comment you are reacting to, written by {{actor_name}}:

--- a/src/AreWeDoomd.Application/Notifications/Engine/CommentCreatedNotificationRule.cs
+++ b/src/AreWeDoomd.Application/Notifications/Engine/CommentCreatedNotificationRule.cs
@@ -48,7 +48,7 @@ public sealed class CommentCreatedNotificationRule(INotificationRecipientLookup 
             byUserId[userId] = BuildRecipient(
                 userId,
                 commenter.RecipientType,
-                NotificationReason.ThreadParticipant,
+                NotificationReason.PostParticipant,
                 template: "post.comment.reply",
                 dedupeKey: $"comment.created:{context.ObjectId}:participant:{userId}",
                 context);

--- a/src/AreWeDoomd.Application/Notifications/Engine/INotificationRecipientLookup.cs
+++ b/src/AreWeDoomd.Application/Notifications/Engine/INotificationRecipientLookup.cs
@@ -7,7 +7,7 @@ public interface INotificationRecipientLookup
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Distinct identities of every user who has commented on the post (the thread
+    /// Distinct identities of every user who has commented on the post (the post
     /// participants). Used to notify earlier commenters when a new reply lands.
     /// </summary>
     Task<IReadOnlyList<NotificationRecipientIdentity>> GetCommenterIdentitiesAsync(

--- a/tests/AreWeDoomd.UnitTests/AgentService/Processing/AgentEventProcessorTests.cs
+++ b/tests/AreWeDoomd.UnitTests/AgentService/Processing/AgentEventProcessorTests.cs
@@ -140,7 +140,7 @@ public sealed class AgentEventProcessorTests
     {
         _contextFetcher
             .Setup(f => f.FetchAsync(PostId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((PostThreadContext?)null);
+            .ReturnsAsync((PostContext?)null);
         var processor = CreateProcessor();
 
         await processor.ProcessSingleAsync(SampleEvent(ActorType.Human), CancellationToken.None);
@@ -177,27 +177,27 @@ public sealed class AgentEventProcessorTests
             NullLogger<AgentEventProcessor>.Instance);
     }
 
-    private static PostThreadContext SampleContext(params string[] extraAiTailTypes)
+    private static PostContext SampleContext(params string[] extraAiTailTypes)
     {
-        var comments = new List<ThreadComment>
+        var comments = new List<CommentInfo>
         {
             new(Guid.NewGuid(), "alice", "Human", "First!", DateTimeOffset.UtcNow.AddMinutes(-10))
         };
 
         foreach (string type in extraAiTailTypes)
         {
-            comments.Add(new ThreadComment(
+            comments.Add(new CommentInfo(
                 Guid.NewGuid(), "otherbot", type, "beep", DateTimeOffset.UtcNow.AddMinutes(-5)));
         }
 
-        comments.Add(new ThreadComment(
+        comments.Add(new CommentInfo(
             CommentId,
             extraAiTailTypes.Length > 0 ? "otherbot" : "alice",
             extraAiTailTypes.Length > 0 ? "Ai" : "Human",
             "What do you think?",
             DateTimeOffset.UtcNow));
 
-        return new PostThreadContext(
+        return new PostContext(
             new PostInfo(PostId, "doombot", "Ai", "Is AGI near?"),
             comments);
     }

--- a/tests/AreWeDoomd.UnitTests/AgentService/Processing/PriorityDecayPolicyTests.cs
+++ b/tests/AreWeDoomd.UnitTests/AgentService/Processing/PriorityDecayPolicyTests.cs
@@ -21,7 +21,7 @@ public sealed class PriorityDecayPolicyTests
         NotificationPriority priority,
         EffectivePriority expected)
     {
-        var comments = Thread("Ai", "Ai", "Ai", "Ai");
+        var comments = Comments("Ai", "Ai", "Ai", "Ai");
 
         var result = _policy.Evaluate(ActorType.Human, priority, comments);
 
@@ -31,7 +31,7 @@ public sealed class PriorityDecayPolicyTests
     [Fact]
     public void Evaluate_WhenAiActorDepth1_ShouldBeNormal()
     {
-        var comments = Thread("Human", "Ai");
+        var comments = Comments("Human", "Ai");
 
         var result = _policy.Evaluate(ActorType.Ai, NotificationPriority.Normal, comments);
 
@@ -41,7 +41,7 @@ public sealed class PriorityDecayPolicyTests
     [Fact]
     public void Evaluate_WhenAiActorDepth2_ShouldBeLow()
     {
-        var comments = Thread("Human", "Ai", "Ai");
+        var comments = Comments("Human", "Ai", "Ai");
 
         var result = _policy.Evaluate(ActorType.Ai, NotificationPriority.Normal, comments);
 
@@ -51,7 +51,7 @@ public sealed class PriorityDecayPolicyTests
     [Fact]
     public void Evaluate_WhenAiActorDepth3_ShouldBeLowClosing()
     {
-        var comments = Thread("Human", "Ai", "Ai", "Ai");
+        var comments = Comments("Human", "Ai", "Ai", "Ai");
 
         var result = _policy.Evaluate(ActorType.Ai, NotificationPriority.Normal, comments);
 
@@ -61,7 +61,7 @@ public sealed class PriorityDecayPolicyTests
     [Fact]
     public void Evaluate_WhenAiActorDepth4_ShouldBeSkip()
     {
-        var comments = Thread("Ai", "Ai", "Ai", "Ai");
+        var comments = Comments("Ai", "Ai", "Ai", "Ai");
 
         var result = _policy.Evaluate(ActorType.Ai, NotificationPriority.Normal, comments);
 
@@ -71,17 +71,17 @@ public sealed class PriorityDecayPolicyTests
     [Fact]
     public void Evaluate_WhenAiActorButHumanBrokeTheChain_ShouldResetDepth()
     {
-        var comments = Thread("Ai", "Ai", "Human", "Ai");
+        var comments = Comments("Ai", "Ai", "Human", "Ai");
 
         var result = _policy.Evaluate(ActorType.Ai, NotificationPriority.Normal, comments);
 
         result.ShouldBe(EffectivePriority.Normal);
     }
 
-    private static List<ThreadComment> Thread(params string[] authorTypes)
+    private static List<CommentInfo> Comments(params string[] authorTypes)
     {
         return authorTypes
-            .Select((type, index) => new ThreadComment(
+            .Select((type, index) => new CommentInfo(
                 Guid.NewGuid(),
                 $"user{index}",
                 type,

--- a/tests/AreWeDoomd.UnitTests/AgentService/Prompting/PromptComposerTests.cs
+++ b/tests/AreWeDoomd.UnitTests/AgentService/Prompting/PromptComposerTests.cs
@@ -22,7 +22,7 @@ public sealed class PromptComposerTests : IDisposable
             Path.Combine(_root, "10-personalities", "default.md"), "PERSONALITY");
         File.WriteAllText(
             Path.Combine(_root, "20-tasks", "comment-created.md"),
-            "actor={{actor_name}} post={{post_content}} thread={{comment_thread}} " +
+            "actor={{actor_name}} post={{post_content}} comments={{comments}} " +
             "incoming={{incoming_comment}} prio={{priority_instruction}}");
         File.WriteAllText(
             Path.Combine(_root, "30-priority-instructions", "high.md"), "PRIO-HIGH");
@@ -53,7 +53,7 @@ public sealed class PromptComposerTests : IDisposable
 
         prompt.UserMessage.ShouldContain("actor=Alice");
         prompt.UserMessage.ShouldContain("post=My post");
-        prompt.UserMessage.ShouldContain("thread=Alice (Human): hi");
+        prompt.UserMessage.ShouldContain("comments=Alice (Human): hi");
         prompt.UserMessage.ShouldContain("incoming=hi");
         prompt.UserMessage.ShouldContain("prio=PRIO-NORMAL");
         prompt.UserMessage.ShouldNotContain("{{");
@@ -85,7 +85,7 @@ public sealed class PromptComposerTests : IDisposable
         return new CommentCreatedPromptInput(
             ActorName: "Alice",
             PostContent: "My post",
-            CommentThread: "Alice (Human): hi",
+            Comments: "Alice (Human): hi",
             IncomingComment: "hi",
             Priority: priority);
     }

--- a/tests/AreWeDoomd.UnitTests/Notifications/ActivityNotificationEngineTests.cs
+++ b/tests/AreWeDoomd.UnitTests/Notifications/ActivityNotificationEngineTests.cs
@@ -77,7 +77,7 @@ public sealed class ActivityNotificationEngineTests
         owner.Template.ShouldBe("post.comment.created");
 
         var participant = result.Recipients.Single(r => r.UserId == otherCommenterId.ToString());
-        participant.Reason.ShouldBe(NotificationReason.ThreadParticipant);
+        participant.Reason.ShouldBe(NotificationReason.PostParticipant);
         participant.Template.ShouldBe("post.comment.reply");
         participant.RecipientType.ShouldBe(NotificationRecipientType.Ai);
         participant.Params["actor_name"].ShouldBe("Ali");


### PR DESCRIPTION
Renamed ThreadComment to CommentInfo and PostThreadContext to PostContext. Updated all references, variable names, and comments from "thread" to "post" or "comments" for clarity. Changed NotificationReason.ThreadParticipant to PostParticipant. Renamed CommentThreadFormatter to CommentListFormatter. Updated IContextFetcher and related logic to use new types. Adjusted prompt templates and unit tests to match new terminology. Improved naming consistency to clarify comments are linked to posts, not threads.