### PR TITLE
fix(routing): replace :guid constraints with model binding for consis…

### DIFF
--- a/src/AreWeDoomd.Api/Controllers/CommentLikesController.cs
+++ b/src/AreWeDoomd.Api/Controllers/CommentLikesController.cs
@@ -16,7 +16,7 @@ namespace AreWeDoomd.Api.Controllers;
 [Authorize]
 public sealed class CommentLikesController(IMediator mediator) : ControllerBase
 {
-    [HttpPost("{postId:guid}/comments/{commentId:guid}/likes")]
+    [HttpPost("{postId}/comments/{commentId}/likes")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -36,7 +36,7 @@ public sealed class CommentLikesController(IMediator mediator) : ControllerBase
         return this.ToNoContentResult(result);
     }
 
-    [HttpDelete("{postId:guid}/comments/{commentId:guid}/likes")]
+    [HttpDelete("{postId}/comments/{commentId}/likes")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -55,7 +55,7 @@ public sealed class CommentLikesController(IMediator mediator) : ControllerBase
         return this.ToNoContentResult(result);
     }
 
-    [HttpGet("{postId:guid}/comments/{commentId:guid}/likes")]
+    [HttpGet("{postId}/comments/{commentId}/likes")]
     [ProducesResponseType(typeof(List<CommentLikeUserResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/AreWeDoomd.Api/Controllers/CommentsController.cs
+++ b/src/AreWeDoomd.Api/Controllers/CommentsController.cs
@@ -19,7 +19,7 @@ namespace AreWeDoomd.Api.Controllers;
 [Route("api/posts")]
 public sealed class CommentsController(IMediator mediator) : ControllerBase
 {
-    [HttpPost("{postId:guid}/comments")]
+    [HttpPost("{postId}/comments")]
     [Authorize]
     [PublishActivity(ActivityType.CommentCreated, ActivityTargetType.Post, targetIdParam: "postId")]
     [ProducesResponseType(typeof(CommentResponse), StatusCodes.Status200OK)]
@@ -43,7 +43,7 @@ public sealed class CommentsController(IMediator mediator) : ControllerBase
         return this.ToActionResult(result, MapComment);
     }
 
-    [HttpGet("{postId:guid}/comments")]
+    [HttpGet("{postId}/comments")]
     [AllowAnonymous]
     [ProducesResponseType(typeof(CommentListResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
@@ -66,7 +66,7 @@ public sealed class CommentsController(IMediator mediator) : ControllerBase
         return this.ToActionResult(result, MapCommentList);
     }
 
-    [HttpPatch("{postId:guid}/comments/{commentId:guid}")]
+    [HttpPatch("{postId}/comments/{commentId}")]
     [Authorize]
     [ProducesResponseType(typeof(CommentResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
@@ -91,7 +91,7 @@ public sealed class CommentsController(IMediator mediator) : ControllerBase
         return this.ToActionResult(result, MapComment);
     }
 
-    [HttpDelete("{postId:guid}/comments/{commentId:guid}")]
+    [HttpDelete("{postId}/comments/{commentId}")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]

--- a/src/AreWeDoomd.Api/Controllers/PostLikesController.cs
+++ b/src/AreWeDoomd.Api/Controllers/PostLikesController.cs
@@ -16,7 +16,7 @@ namespace AreWeDoomd.Api.Controllers;
 [Authorize]
 public sealed class PostLikesController(IMediator mediator) : ControllerBase
 {
-    [HttpPost("{postId:guid}/likes")]
+    [HttpPost("{postId}/likes")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -35,7 +35,7 @@ public sealed class PostLikesController(IMediator mediator) : ControllerBase
         return this.ToNoContentResult(result);
     }
 
-    [HttpDelete("{postId:guid}/likes")]
+    [HttpDelete("{postId}/likes")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -52,7 +52,7 @@ public sealed class PostLikesController(IMediator mediator) : ControllerBase
         return this.ToNoContentResult(result);
     }
 
-    [HttpGet("{postId:guid}/likes")]
+    [HttpGet("{postId}/likes")]
     [ProducesResponseType(typeof(List<PostLikeUserResponse>), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/src/AreWeDoomd.Api/Controllers/PostsController.cs
+++ b/src/AreWeDoomd.Api/Controllers/PostsController.cs
@@ -38,7 +38,7 @@ public sealed class PostsController(IMediator mediator) : ControllerBase
         return this.ToActionResult(result, MapPost);
     }
 
-    [HttpGet("{postId:guid}")]
+    [HttpGet("{postId}")]
     [AllowAnonymous]
     [ProducesResponseType(typeof(PostResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
@@ -52,7 +52,7 @@ public sealed class PostsController(IMediator mediator) : ControllerBase
         return this.ToActionResult(result, MapPost);
     }
 
-    [HttpPatch("{postId:guid}")]
+    [HttpPatch("{postId}")]
     [ProducesResponseType(typeof(PostResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
@@ -75,7 +75,7 @@ public sealed class PostsController(IMediator mediator) : ControllerBase
         return this.ToActionResult(result, MapPost);
     }
 
-    [HttpDelete("{postId:guid}")]
+    [HttpDelete("{postId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/AreWeDoomd.Api/Program.cs
+++ b/src/AreWeDoomd.Api/Program.cs
@@ -1,4 +1,5 @@
 using AreWeDoomd.Api.Auth;
+using Microsoft.AspNetCore.Mvc;
 using AreWeDoomd.Api.Common.Errors;
 using AreWeDoomd.Api.Notifications;
 using AreWeDoomd.Api.Realtime;
@@ -28,7 +29,26 @@ try
         .Enrich.FromLogContext()
         .AddInfrastructureSinks(ctx.Configuration));
 
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+        .ConfigureApiBehaviorOptions(options =>
+        {
+            options.InvalidModelStateResponseFactory = context =>
+            {
+                var errors = context.ModelState
+                    .Where(e => e.Value?.Errors.Count > 0)
+                    .ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => kvp.Value!.Errors.Select(e => e.ErrorMessage).Distinct().ToArray());
+
+                return new BadRequestObjectResult(
+                    new HttpValidationProblemDetails(errors)
+                    {
+                        Title = "Validation failed",
+                        Detail = "One or more validation errors occurred.",
+                        Status = StatusCodes.Status400BadRequest
+                    });
+            };
+        });
     builder.Services.AddProblemDetails();
     builder.Services.AddExceptionHandler<ApiExceptionHandler>();
     builder.Services.AddOpenApi();


### PR DESCRIPTION
 Problem

  Route parameters typed as `Guid` with `:guid` route constraints caused
  ASP.NET to silently return 404 when a malformed value (e.g. "not-a-guid")
  was supplied. The `:guid` constraint acts as a route-matching filter, so
  the request never matched the route at all — it bypassed the controller,
  the MediatR pipeline, and all custom error handling entirely.

  This meant a client sending a bad ID got a misleading "Not Found" instead
  of a "Bad Request", and the response format was inconsistent with every
  other validation error in the API.

Two-part fix:

  1. Remove `:guid` route constraints from route templates where they serve no disambiguation purpose. The `Guid` parameter type is kept on the action methods, so ASP.NET model binding still rejects non-GUID values — the difference is that a bad value now fails at binding (→ 400) rather than at routing (→ 404).

  2. Configure `InvalidModelStateResponseFactory` in Program.cs so that model binding failures produce the same `HttpValidationProblemDetails` shape that `ControllerResultExtensions` already returns for application-layer validation errors


Testing

  Full end-to-end test run against a live instance connected to the Azure
  SQL database. Every route across all 10 controllers was exercised:

    AuthController       — register (human + ai paths), login, me,
                           forgot-password
    PostsController      — create, get, update, delete
    CommentsController   — create, get, update, delete
    PostLikesController  — like, unlike, get likes
    CommentLikesController — like, unlike, get likes
    FollowsController    — follow, unfollow, me/followers, me/following,
                           {username}/followers, {username}/following
    NotificationsController — get, unread-count, mark-all-read
    FeedController       — global, following
    SearchController     — search users, search posts
    UsersController      — me, discover, get by username, get by guid,
                           update profile, change password, update
                           profile image, my posts, user posts feed,
                           liked posts feed

  Malformed GUID verified on posts, comments, and comment-likes routes —
  all return 400 with the "Validation failed" body. No regressions found.