### PR TITLE
feat: add OpenRouter as a selectable chat provider for the AI agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -798,3 +798,4 @@ fabric.properties
 
 # Local container environment values (secrets) — see .env.example
 .env
+/docs/superpowers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,11 @@ services:
       AgentNotifications__HubUrl: http://api:8080/hubs/agent-notifications
       AgentNotifications__ApiBaseUrl: http://api:8080
       AgentNotifications__SharedSecret: ${AGENT_SHARED_SECRET}
-      # Passed raw (not ChatProviders__Gemini__ApiKey): the AgentService's
-      # Program.cs maps GEMINI_API_KEY onto ChatProviders:Gemini:ApiKey itself.
+      # Passed raw (not ChatProviders__OpenRouter__ApiKey): the AgentService's
+      # Program.cs maps OPENROUTER_API_KEY onto ChatProviders:OpenRouter:ApiKey
+      # itself, same as GEMINI_API_KEY.
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       ChatProviders__Anthropic__ApiKey: ${ANTHROPIC_API_KEY:-}
 
   redis:

--- a/src/AreWeDoomd.AgentService/Ai/ChatProviderServiceCollectionExtensions.cs
+++ b/src/AreWeDoomd.AgentService/Ai/ChatProviderServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using AreWeDoomd.AgentService.Ai.Providers.Gemini;
+using AreWeDoomd.AgentService.Ai.Providers.OpenRouter;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,9 +18,11 @@ public static class ChatProviderServiceCollectionExtensions
     {
         // ===== PROVIDER PLUG-IN POINT ===================================
         // Adding a provider later = one new adapter file (clone
-        // AnthropicProvider) + one registration line below. Nothing else in
-        // this method or the consuming code needs to change.
+        // GeminiProvider or OpenRouterProvider) + one registration line
+        // below. Nothing else in this method or the consuming code needs
+        // to change.
         AddGeminiProvider(services, configuration);
+        AddOpenRouterProvider(services, configuration);
         // ================================================================
 
         return services;
@@ -39,5 +42,18 @@ public static class ChatProviderServiceCollectionExtensions
         services.AddHttpClient(GeminiProvider.HttpClientName);
 
         services.AddKeyedSingleton<IChatProvider, GeminiProvider>(GeminiProvider.ProviderName);
+    }
+
+    private static void AddOpenRouterProvider(IServiceCollection services, IConfiguration configuration)
+    {
+        services
+            .AddOptions<OpenRouterProviderOptions>()
+            .Bind(configuration.GetSection(OpenRouterProviderOptions.SectionName))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddHttpClient(OpenRouterProvider.HttpClientName);
+
+        services.AddKeyedSingleton<IChatProvider, OpenRouterProvider>(OpenRouterProvider.ProviderName);
     }
 }

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/OpenRouterProvider.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/OpenRouterProvider.cs
@@ -1,0 +1,243 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter;
+
+/// <summary>
+/// Hand-rolled adapter for OpenRouter's OpenAI-compatible chat completions API.
+/// Cloned from <c>GeminiProvider</c>: it owns its wire DTOs, never lets
+/// provider-specific types escape, and obeys the same hard rules — callers only
+/// ever see <see cref="ChatResult"/>.
+/// </summary>
+public sealed class OpenRouterProvider : IChatProvider
+{
+    public const string ProviderName = "openrouter";
+    public const string HttpClientName = "openrouter";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly HashSet<int> RetryableStatusCodes = [429, 502, 503, 504];
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly OpenRouterProviderOptions _options;
+    private readonly ILogger<OpenRouterProvider> _logger;
+
+    public OpenRouterProvider(
+        IHttpClientFactory httpClientFactory,
+        IOptions<OpenRouterProviderOptions> options,
+        ILogger<OpenRouterProvider> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public string Name => ProviderName;
+
+    public async Task<ChatResult> CompleteAsync(ChatRequest request, CancellationToken ct)
+    {
+        int maxAttempts = _options.MaxRetries + 1;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            bool shouldRetry = false;
+            int statusCode = 0;
+
+            try
+            {
+                using var httpRequest = BuildHttpRequest(request);
+                HttpClient client = _httpClientFactory.CreateClient(HttpClientName);
+
+                using HttpResponseMessage response = await client.SendAsync(httpRequest, ct);
+                statusCode = (int)response.StatusCode;
+                string responseBody = await response.Content.ReadAsStringAsync(ct);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    if (RetryableStatusCodes.Contains(statusCode) && attempt < maxAttempts)
+                    {
+                        shouldRetry = true;
+                    }
+                    else
+                    {
+                        return ChatResult.Fail(NormalizeError(responseBody, statusCode));
+                    }
+                }
+                else
+                {
+                    return BuildResult(responseBody, statusCode);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException or IOException)
+            {
+                _logger.LogWarning(ex, "Transport failure calling the OpenRouter chat completions API");
+                return ChatResult.Fail(new ChatError(ex.Message, StatusCode: null, ProviderName));
+            }
+
+            if (shouldRetry)
+            {
+                int delayMs = _options.RetryBaseDelayMs * (int)Math.Pow(2, attempt - 1);
+                _logger.LogWarning(
+                    "OpenRouter returned {StatusCode} (transient) on attempt {Attempt}/{Max}; retrying in {DelayMs}ms",
+                    statusCode, attempt, maxAttempts, delayMs);
+                await Task.Delay(delayMs, ct);
+            }
+        }
+
+        return ChatResult.Fail(new ChatError(
+            $"OpenRouter request failed after {_options.MaxRetries} retries.",
+            null,
+            ProviderName));
+    }
+
+    private HttpRequestMessage BuildHttpRequest(ChatRequest request)
+    {
+        string model = string.IsNullOrWhiteSpace(request.Model)
+            ? _options.DefaultModel
+            : request.Model;
+
+        int maxTokens = request.MaxTokens ?? _options.DefaultMaxTokens;
+
+        var messages = new List<OpenRouterMessage>();
+        if (!string.IsNullOrWhiteSpace(request.System))
+        {
+            messages.Add(new OpenRouterMessage("system", request.System));
+        }
+
+        messages.AddRange(request.Messages.Select(message => new OpenRouterMessage("user", message.Content)));
+
+        OpenRouterResponseFormat? responseFormat = null;
+        if (!string.IsNullOrWhiteSpace(request.JsonResponseSchema))
+        {
+            using JsonDocument schemaDocument = JsonDocument.Parse(request.JsonResponseSchema);
+            responseFormat = new OpenRouterResponseFormat
+            {
+                Type = "json_schema",
+                JsonSchema = new OpenRouterJsonSchema
+                {
+                    Name = "response",
+                    Schema = schemaDocument.RootElement.Clone()
+                }
+            };
+        }
+
+        var payload = new OpenRouterChatCompletionRequest
+        {
+            Model = model,
+            Messages = messages,
+            MaxTokens = maxTokens,
+            Temperature = request.Temperature,
+            ResponseFormat = responseFormat
+        };
+
+        string json = JsonSerializer.Serialize(payload, SerializerOptions);
+
+        var httpRequest = new HttpRequestMessage(HttpMethod.Post, BuildRequestUri())
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        httpRequest.Headers.Add("Authorization", $"Bearer {_options.ApiKey}");
+        if (!string.IsNullOrWhiteSpace(_options.SiteUrl))
+        {
+            httpRequest.Headers.Add("HTTP-Referer", _options.SiteUrl);
+        }
+
+        if (!string.IsNullOrWhiteSpace(_options.SiteName))
+        {
+            httpRequest.Headers.Add("X-Title", _options.SiteName);
+        }
+
+        return httpRequest;
+    }
+
+    private Uri BuildRequestUri()
+    {
+        string baseUrl = _options.BaseUrl.TrimEnd('/');
+        return new Uri($"{baseUrl}/chat/completions");
+    }
+
+    private ChatResult BuildResult(string responseBody, int statusCode)
+    {
+        OpenRouterChatCompletionResponse? parsed;
+        try
+        {
+            parsed = JsonSerializer.Deserialize<OpenRouterChatCompletionResponse>(responseBody, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            // 200 OK but the body is not something we can read — no usable answer.
+            _logger.LogWarning(ex, "Could not parse a successful OpenRouter response body");
+            return ChatResult.Fail(new ChatError(
+                "OpenRouter returned a response that could not be parsed.",
+                statusCode,
+                ProviderName));
+        }
+
+        OpenRouterChoice? choice = parsed?.Choices is { Count: > 0 } choices
+            ? choices[0]
+            : null;
+
+        FinishReason finish = MapFinishReason(choice?.FinishReason);
+        string text = choice?.Message?.Content ?? string.Empty;
+
+        // Rule #4: a content-filter stop (or any empty body) is a Fail, not an
+        // Ok carrying empty text.
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            string message = finish == FinishReason.ContentFilter
+                ? "OpenRouter stopped on a content filter and returned no text."
+                : "OpenRouter returned no usable text content.";
+            return ChatResult.Fail(new ChatError(message, statusCode, ProviderName));
+        }
+
+        var usage = parsed?.Usage is { } u
+            ? new TokenUsage(u.PromptTokens, u.CompletionTokens)
+            : new TokenUsage(0, 0);
+
+        return ChatResult.Ok(text, usage, finish);
+    }
+
+    private ChatError NormalizeError(string responseBody, int statusCode)
+    {
+        string? message = null;
+        try
+        {
+            OpenRouterErrorResponse? error =
+                JsonSerializer.Deserialize<OpenRouterErrorResponse>(responseBody, SerializerOptions);
+            message = error?.Error?.Message;
+        }
+        catch (JsonException)
+        {
+            // Non-JSON error body — fall through to the raw-body fallback below.
+        }
+
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            message = string.IsNullOrWhiteSpace(responseBody)
+                ? $"OpenRouter request failed with status {statusCode}."
+                : responseBody.Trim();
+        }
+
+        return new ChatError(message, statusCode, ProviderName);
+    }
+
+    private static FinishReason MapFinishReason(string? finishReason) => finishReason switch
+    {
+        "stop" => FinishReason.Stop,
+        "length" => FinishReason.MaxTokens,
+        "content_filter" => FinishReason.ContentFilter,
+        _ => FinishReason.Other
+    };
+}

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/OpenRouterProviderOptions.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/OpenRouterProviderOptions.cs
@@ -1,0 +1,18 @@
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter;
+
+public sealed class OpenRouterProviderOptions : ChatProviderOptions
+{
+    public const string SectionName = "ChatProviders:OpenRouter";
+
+    /// <summary>How many times to retry after a transient error (429/502/503/504). 0 = no retry.</summary>
+    public int MaxRetries { get; set; } = 3;
+
+    /// <summary>Base delay in milliseconds for the first retry. Doubles with each attempt.</summary>
+    public int RetryBaseDelayMs { get; set; } = 2000;
+
+    /// <summary>Optional attribution header (HTTP-Referer) OpenRouter uses for its public rankings. Omitted when blank.</summary>
+    public string SiteUrl { get; set; } = string.Empty;
+
+    /// <summary>Optional attribution header (X-Title) OpenRouter uses for its public rankings. Omitted when blank.</summary>
+    public string SiteName { get; set; } = string.Empty;
+}

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterChatCompletionRequest.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterChatCompletionRequest.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+/// <summary>
+/// Request body for <c>POST {BaseUrl}/chat/completions</c>. Null optional
+/// fields are omitted during serialization.
+/// </summary>
+internal sealed record OpenRouterChatCompletionRequest
+{
+    [JsonPropertyName("model")]
+    public required string Model { get; init; }
+
+    [JsonPropertyName("messages")]
+    public required IReadOnlyList<OpenRouterMessage> Messages { get; init; }
+
+    [JsonPropertyName("max_tokens")]
+    public int? MaxTokens { get; init; }
+
+    [JsonPropertyName("temperature")]
+    public double? Temperature { get; init; }
+
+    [JsonPropertyName("response_format")]
+    public OpenRouterResponseFormat? ResponseFormat { get; init; }
+}

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterChatCompletionResponse.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterChatCompletionResponse.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+/// <summary>
+/// Successful response body from <c>chat/completions</c>. Only the fields the
+/// adapter consumes are modelled; everything else is ignored.
+/// </summary>
+internal sealed record OpenRouterChatCompletionResponse
+{
+    [JsonPropertyName("choices")]
+    public IReadOnlyList<OpenRouterChoice>? Choices { get; init; }
+
+    [JsonPropertyName("usage")]
+    public OpenRouterUsage? Usage { get; init; }
+}

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterChoice.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterChoice.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+internal sealed record OpenRouterChoice
+{
+    [JsonPropertyName("message")]
+    public OpenRouterResponseMessage? Message { get; init; }
+
+    [JsonPropertyName("finish_reason")]
+    public string? FinishReason { get; init; }
+}

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterError.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterError.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+internal sealed record OpenRouterError(
+    [property: JsonPropertyName("message")] string? Message);

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterErrorResponse.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterErrorResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+/// <summary>
+/// Error envelope returned by OpenRouter on non-2xx responses, e.g.
+/// <c>{"error":{"message":"...","code":429}}</c>.
+/// </summary>
+internal sealed record OpenRouterErrorResponse(
+    [property: JsonPropertyName("error")] OpenRouterError? Error);

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterJsonSchema.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterJsonSchema.cs
@@ -1,0 +1,13 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+internal sealed record OpenRouterJsonSchema
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("schema")]
+    public required JsonElement Schema { get; init; }
+}

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterMessage.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterMessage.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+/// <summary>
+/// A single chat-completions message. Used for both request turns (role
+/// "system"/"user") and the response message (role "assistant").
+/// </summary>
+internal sealed record OpenRouterMessage(
+    [property: JsonPropertyName("role")] string Role,
+    [property: JsonPropertyName("content")] string Content);

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterResponseFormat.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterResponseFormat.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+internal sealed record OpenRouterResponseFormat
+{
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    [JsonPropertyName("json_schema")]
+    public OpenRouterJsonSchema? JsonSchema { get; init; }
+}

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterResponseMessage.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterResponseMessage.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+internal sealed record OpenRouterResponseMessage(
+    [property: JsonPropertyName("role")] string? Role,
+    [property: JsonPropertyName("content")] string? Content);

--- a/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterUsage.cs
+++ b/src/AreWeDoomd.AgentService/Ai/Providers/OpenRouter/Wire/OpenRouterUsage.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+
+namespace AreWeDoomd.AgentService.Ai.Providers.OpenRouter.Wire;
+
+internal sealed record OpenRouterUsage(
+    [property: JsonPropertyName("prompt_tokens")] int PromptTokens,
+    [property: JsonPropertyName("completion_tokens")] int CompletionTokens);

--- a/src/AreWeDoomd.AgentService/Program.cs
+++ b/src/AreWeDoomd.AgentService/Program.cs
@@ -26,6 +26,17 @@ if (!string.IsNullOrWhiteSpace(geminiApiKey))
     });
 }
 
+// Map the conventional OPENROUTER_API_KEY environment variable onto the
+// provider's config key, same pattern as GEMINI_API_KEY above.
+string? openRouterApiKey = Environment.GetEnvironmentVariable("OPENROUTER_API_KEY");
+if (!string.IsNullOrWhiteSpace(openRouterApiKey))
+{
+    builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+    {
+        ["ChatProviders:OpenRouter:ApiKey"] = openRouterApiKey
+    });
+}
+
 builder.Services.AddSerilog((services, loggerConfig) =>
 {
     loggerConfig

--- a/src/AreWeDoomd.AgentService/appsettings.json
+++ b/src/AreWeDoomd.AgentService/appsettings.json
@@ -28,6 +28,16 @@
       "DefaultModel": "gemini-2.5-flash",
       "DefaultMaxTokens": 1024,
       "ApiVersion": "v1beta"
+    },
+    "OpenRouter": {
+      "ApiKey": "",
+      "BaseUrl": "https://openrouter.ai/api/v1",
+      "DefaultModel": "",
+      "DefaultMaxTokens": 1024,
+      "MaxRetries": 3,
+      "RetryBaseDelayMs": 2000,
+      "SiteUrl": "",
+      "SiteName": ""
     }
   }
 }

--- a/tests/AreWeDoomd.UnitTests/AgentService/Ai/OpenRouterProviderTests.cs
+++ b/tests/AreWeDoomd.UnitTests/AgentService/Ai/OpenRouterProviderTests.cs
@@ -1,0 +1,216 @@
+using System.Net;
+using AreWeDoomd.AgentService.Ai;
+using AreWeDoomd.AgentService.Ai.Providers.OpenRouter;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AreWeDoomd.UnitTests.AgentService.Ai;
+
+public sealed class OpenRouterProviderTests
+{
+    private static readonly ChatRequest SampleRequest = new(
+        Model: "openai/gpt-4o-mini",
+        Messages: [new ChatMessage("Are we doomed?")],
+        System: "You are concise.",
+        MaxTokens: 256,
+        Temperature: 0.7);
+
+    [Fact]
+    public async Task CompleteAsync_WhenProviderReturns429_ShouldReturnFailWithoutThrowing()
+    {
+        const string body = """
+        {"error":{"message":"Rate limit exceeded, please try again later.","code":429}}
+        """;
+        // MaxRetries=0 → single attempt, no retry delay.
+        var provider = CreateProvider(
+            StubHttpMessageHandler.AlwaysRespondWith(() => new HttpResponseMessage((HttpStatusCode)429)
+            {
+                Content = new StringContent(body)
+            }),
+            maxRetries: 0);
+
+        var result = await provider.CompleteAsync(SampleRequest, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldNotBeNull();
+        result.Error!.StatusCode.ShouldBe(429);
+        result.Error.Provider.ShouldBe("openrouter");
+        result.Error.Message.ShouldContain("Rate limit exceeded");
+        result.Text.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenProviderReturns503Consistently_ShouldRetryAndReturnFail()
+    {
+        const string body = """
+        {"error":{"message":"The model is temporarily unavailable due to high demand.","code":503}}
+        """;
+        int callCount = 0;
+        var handler = StubHttpMessageHandler.AlwaysRespondWith(() =>
+        {
+            callCount++;
+            return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = new StringContent(body)
+            };
+        });
+        var provider = CreateProvider(handler, maxRetries: 2, retryBaseDelayMs: 0);
+
+        var result = await provider.CompleteAsync(SampleRequest, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldNotBeNull();
+        result.Error!.Provider.ShouldBe("openrouter");
+        callCount.ShouldBe(3); // 1 initial + 2 retries
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenProviderReturns503ThenSucceeds_ShouldReturnSuccess()
+    {
+        const string errorBody = """
+        {"error":{"message":"The model is temporarily unavailable due to high demand.","code":503}}
+        """;
+        const string okBody = """
+        {"choices":[{"message":{"role":"assistant","content":"We are fine."},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}
+        """;
+        int callCount = 0;
+        var handler = StubHttpMessageHandler.AlwaysRespondWith(() =>
+        {
+            callCount++;
+            return callCount == 1
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new StringContent(errorBody) }
+                : new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(okBody) };
+        });
+        var provider = CreateProvider(handler, maxRetries: 2, retryBaseDelayMs: 0);
+
+        var result = await provider.CompleteAsync(SampleRequest, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        result.Text.ShouldBe("We are fine.");
+        callCount.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenTransportFails_ShouldReturnFailWithoutThrowing()
+    {
+        var handler = StubHttpMessageHandler.Throw(
+            new HttpRequestException("No such host is known."));
+        var provider = CreateProvider(handler);
+
+        // A throw here fails the test — proving CompleteAsync swallows the
+        // transport exception and returns a normalized failure instead.
+        var result = await provider.CompleteAsync(SampleRequest, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeFalse();
+        result.Error.ShouldNotBeNull();
+        result.Error!.Provider.ShouldBe("openrouter");
+        result.Error.StatusCode.ShouldBeNull();
+        result.Text.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenSystemPromptSet_ShouldPrependSystemRoleMessage()
+    {
+        string? requestBody = null;
+        const string okBody = """
+        {"choices":[{"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}
+        """;
+        var handler = new StubHttpMessageHandler(async (req, _) =>
+        {
+            requestBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(okBody)
+            };
+        });
+        var provider = CreateProvider(handler);
+
+        var result = await provider.CompleteAsync(SampleRequest, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        requestBody.ShouldNotBeNull();
+        requestBody.ShouldStartWith("""{"model":"openai/gpt-4o-mini","messages":[{"role":"system","content":"You are concise."},{"role":"user","content":"Are we doomed?"}]""");
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenJsonResponseSchemaSet_ShouldSendResponseFormat()
+    {
+        string? requestBody = null;
+        const string okBody = """
+        {"choices":[{"message":{"role":"assistant","content":"{\"action\":\"ignore\"}"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}
+        """;
+        var handler = new StubHttpMessageHandler(async (req, _) =>
+        {
+            requestBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(okBody)
+            };
+        });
+        var provider = CreateProvider(handler);
+        var request = SampleRequest with
+        {
+            JsonResponseSchema = """{"type":"object","properties":{"action":{"type":"string"}}}"""
+        };
+
+        var result = await provider.CompleteAsync(request, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        requestBody.ShouldNotBeNull();
+        requestBody.ShouldContain("\"response_format\"");
+        requestBody.ShouldContain("\"json_schema\"");
+    }
+
+    [Fact]
+    public async Task CompleteAsync_WhenNoJsonResponseSchema_ShouldNotSendResponseFormat()
+    {
+        string? requestBody = null;
+        const string okBody = """
+        {"choices":[{"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}
+        """;
+        var handler = new StubHttpMessageHandler(async (req, _) =>
+        {
+            requestBody = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(okBody)
+            };
+        });
+        var provider = CreateProvider(handler);
+
+        var result = await provider.CompleteAsync(SampleRequest, CancellationToken.None);
+
+        result.IsSuccess.ShouldBeTrue();
+        requestBody.ShouldNotBeNull();
+        requestBody.ShouldNotContain("response_format");
+    }
+
+    private static OpenRouterProvider CreateProvider(
+        HttpMessageHandler handler,
+        int maxRetries = 3,
+        int retryBaseDelayMs = 2000)
+    {
+        var factory = new Mock<IHttpClientFactory>();
+        factory
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient(handler));
+
+        var options = Options.Create(new OpenRouterProviderOptions
+        {
+            ApiKey = "test-key",
+            BaseUrl = "https://openrouter.ai/api/v1",
+            DefaultModel = "openai/gpt-4o-mini",
+            DefaultMaxTokens = 1024,
+            MaxRetries = maxRetries,
+            RetryBaseDelayMs = retryBaseDelayMs
+        });
+
+        return new OpenRouterProvider(
+            factory.Object,
+            options,
+            NullLogger<OpenRouterProvider>.Instance);
+    }
+}


### PR DESCRIPTION
feat: add OpenRouter as a selectable chat provider for the AI agent

  Adds OpenRouterProvider, a new IChatProvider adapter targeting
  OpenRouter's OpenAI-compatible chat/completions API, following the
  same plug-in pattern as the existing GeminiProvider (retry on
  429/502/503/504, error normalization, JSON-schema response support).
  Registered as a keyed singleton and selectable via
  AgentNotifications:ChatProvider = "openrouter"; Gemini remains the
  default, so no existing deployment's behavior changes.

  Wires the adapter through:
  - appsettings.json: new ChatProviders:OpenRouter config section
  - Program.cs: OPENROUTER_API_KEY -> ChatProviders:OpenRouter:ApiKey env var mapping, mirroring GEMINI_API_KEY
  - docker-compose.yml: OPENROUTER_API_KEY passthrough for agent-service

  Adds 7 unit tests covering success, 429/503 retry and failure,
  transport failures, system-prompt handling, and JSON-schema
  inclusion/omission. Full suite: 191/191 passing.

  Verified against the live OpenRouter API directly and end-to-end
  through the running API + AgentService + UI stack: a human comment
  triggered a real AgentService -> OpenRouter call whose reply was
  persisted and served back through the app.

  To use it:
  git commit -m "$(cat <<'EOF'
  feat: add OpenRouter as a selectable chat provider for the AI agent

  Adds OpenRouterProvider, a new IChatProvider adapter targeting
  OpenRouter's OpenAI-compatible chat/completions API, following the
  same plug-in pattern as the existing GeminiProvider (retry on
  429/502/503/504, error normalization, JSON-schema response support).
  Registered as a keyed singleton and selectable via
  AgentNotifications:ChatProvider = "openrouter"; Gemini remains the
  default, so no existing deployment's behavior changes.

  Wires the adapter through:
  - appsettings.json: new ChatProviders:OpenRouter config section
  - Program.cs: OPENROUTER_API_KEY -> ChatProviders:OpenRouter:ApiKey env var mapping, mirroring GEMINI_API_KEY
  - docker-compose.yml: OPENROUTER_API_KEY passthrough for agent-service

  Adds 7 unit tests covering success, 429/503 retry and failure,
  transport failures, system-prompt handling, and JSON-schema
  inclusion/omission. Full suite: 191/191 passing.

  Verified against the live OpenRouter API directly and end-to-end
  through the running API + AgentService + UI stack: a human comment
  triggered a real AgentService -> OpenRouter call whose reply was
  persisted and served back through the app.